### PR TITLE
updates to support hard-fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 [[package]]
 name = "rustcommon-atomics"
 version = "1.0.1"
-source = "git+https://github.com/twitter/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
 dependencies = [
  "serde",
 ]
@@ -1214,7 +1214,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-heatmap"
 version = "0.1.2"
-source = "git+https://github.com/twitter/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
 dependencies = [
  "rustcommon-atomics",
  "rustcommon-histogram",
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-histogram"
 version = "1.0.1"
-source = "git+https://github.com/twitter/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
@@ -1234,7 +1234,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-logger"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
 dependencies = [
  "ahash",
  "log",
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics"
 version = "0.1.1"
-source = "git+https://github.com/twitter/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
 dependencies = [
  "linkme",
  "once_cell",
@@ -1260,7 +1260,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics-derive"
 version = "0.1.1"
-source = "git+https://github.com/twitter/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1271,7 +1271,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-ratelimiter"
 version = "1.1.1"
-source = "git+https://github.com/twitter/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
 dependencies = [
  "rand",
  "rand_distr",
@@ -1281,7 +1281,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-time"
 version = "0.0.12"
-source = "git+https://github.com/twitter/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1293,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-waterfall"
 version = "1.0.1"
-source = "git+https://github.com/twitter/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=807b9f7#807b9f7fb123954d383869caa2dfaa17ef7bff4f"
 dependencies = [
  "dejavu",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,12 @@ rand = { version = "0.8.5", features = ["small_rng"] }
 rand_xoshiro = { version = "0.6.0" }
 rand_distr = "0.4.3"
 rtrb = "0.2.2"
-rustcommon-heatmap = { git = "https://github.com/twitter/rustcommon", rev = "807b9f7" }
-rustcommon-logger = { git = "https://github.com/twitter/rustcommon", rev = "807b9f7" }
-rustcommon-ratelimiter = { git = "https://github.com/twitter/rustcommon", rev = "807b9f7" }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon", rev = "807b9f7", features = ["heatmap"] }
-rustcommon-time = { git = "https://github.com/twitter/rustcommon", rev = "807b9f7" }
-rustcommon-waterfall = { git = "https://github.com/twitter/rustcommon", rev = "807b9f7" }
+rustcommon-heatmap = { git = "https://github.com/pelikan-io/rustcommon", rev = "807b9f7" }
+rustcommon-logger = { git = "https://github.com/pelikan-io/rustcommon", rev = "807b9f7" }
+rustcommon-ratelimiter = { git = "https://github.com/pelikan-io/rustcommon", rev = "807b9f7" }
+rustcommon-metrics = { git = "https://github.com/pelikan-io/rustcommon", rev = "807b9f7", features = ["heatmap"] }
+rustcommon-time = { git = "https://github.com/pelikan-io/rustcommon", rev = "807b9f7" }
+rustcommon-waterfall = { git = "https://github.com/pelikan-io/rustcommon", rev = "807b9f7" }
 serde = "1.0.144"
 serde_derive = "1.0.144"
 serde_json = "1.0.85"

--- a/README.md
+++ b/README.md
@@ -74,45 +74,27 @@ rpc-perf configs/memcache.toml
 
 * high-resolution latency metrics
 * supports memcache and redis protocols
-* [mio][mio] for async networking
 * optional waterfall visualization of latencies
 * powerful workload configuration
 
-## Support
-
-Create a [new issue](https://github.com/twitter/rpc-perf/issues/new) on GitHub.
-
 ## Contributing
 
-We feel that a welcoming community is important and we ask that you follow
-Twitter's [Open Source Code of Conduct] in all interactions with the community.
+If you want to submit a patch, please follow these steps:
 
-## Authors
-
-* Brian Martin <bmartin@twitter.com>
-
-A full list of [contributors] can be found on GitHub.
-
-Follow [@TwitterOSS](https://twitter.com/twitteross) on Twitter for updates.
+1. create a new issue
+2. fork on github & clone your fork
+3. create a feature branch on your fork
+4. push your feature branch
+5. create a pull request linked to the issue
 
 ## License
 
-Copyright 2015-2019 Twitter, Inc.
+This software is licensed under the Apache 2.0 license, see [LICENSE](LICENSE) for details.
 
-Licensed under the Apache License, Version 2.0:
-https://www.apache.org/licenses/LICENSE-2.0
-
-## Security Issues?
-
-Please report sensitive security issues via Twitter's bug-bounty program
-(https://hackerone.com/twitter) rather than GitHub.
-
-[ci-build-badge]: https://img.shields.io/github/workflow/status/twitter/rpc-perf/CI/master?label=CI
-[ci-build-url]: https://github.com/twitter/rpc-perf/actions/workflows/cargo.yml?query=branch%3Amaster+event%3Apush
-[contributors]: https://github.com/twitter/rpc-perf/graphs/contributors?type=a
+[ci-build-badge]: https://img.shields.io/github/workflow/status/iopsystems/rpc-perf/CI/master?label=CI
+[ci-build-url]: https://github.com/iopsystems/rpc-perf/actions/workflows/cargo.yml?query=branch%3Amaster+event%3Apush
+[contributors]: https://github.com/iopsystems/rpc-perf/graphs/contributors?type=a
 [license-badge]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
-[license-url]: https://github.com/twitter/rpc-perf/blob/master/LICENSE
-[mio]: https://github.com/carllerche/mio
-[Open Source Code of Conduct]: https://github.com/twitter/code-of-conduct/blob/master/code-of-conduct.md
+[license-url]: https://github.com/iopsystems/rpc-perf/blob/master/LICENSE
 [rustlang]: https://rust-lang.org/
 [rustup]: https://rustup.rs


### PR DESCRIPTION
Updates to support hard-fork including moving rustcommon dependencies to pelikan-io/rustcommon and updating links and readme to reflect the new location of this repository.

