### PR TITLE
docs: fix badge and links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ If you want to submit a patch, please follow these steps:
 
 This software is licensed under the Apache 2.0 license, see [LICENSE](LICENSE) for details.
 
-[ci-build-badge]: https://img.shields.io/github/workflow/status/iopsystems/rpc-perf/CI/master?label=CI
-[ci-build-url]: https://github.com/iopsystems/rpc-perf/actions/workflows/cargo.yml?query=branch%3Amaster+event%3Apush
+[ci-build-badge]: https://img.shields.io/github/workflow/status/iopsystems/rpc-perf/CI/main?label=CI
+[ci-build-url]: https://github.com/iopsystems/rpc-perf/actions/workflows/cargo.yml?query=branch%3Amain+event%3Apush
 [contributors]: https://github.com/iopsystems/rpc-perf/graphs/contributors?type=a
 [license-badge]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
-[license-url]: https://github.com/iopsystems/rpc-perf/blob/master/LICENSE
+[license-url]: https://github.com/iopsystems/rpc-perf/blob/main/LICENSE
 [rustlang]: https://rust-lang.org/
 [rustup]: https://rustup.rs


### PR DESCRIPTION
Fixes badge and links in readme to relfect 'main' as the default branch.
