### PR TITLE
feat: Add a json output mode for use in scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,12 +540,13 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heatmap"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a040d43defb8644617d52575557275232693a27c594d136b16c12283244683"
+checksum = "6bb2f529d678c39a68e7f4227b74f8a84f7013da7b0c56c50226038bab81b7ba"
 dependencies = [
  "clocksource",
  "histogram",
+ "parking_lot",
  "thiserror",
 ]
 
@@ -566,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "histogram"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913e066ae237bc8adb23b539f140ae81152af2dc3ff357ada35af13bcf48f016"
+checksum = "f2cddb1ee43e0813fb269066abae4e09550efca332cc2c639369b64c3b2ebd55"
 dependencies = [
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono = "0.4.22"
 clap = "3.2.20"
 clocksource = "0.6.0"
 crc = "3.0.0"
-heatmap = "0.7.0"
+heatmap = "0.7.2"
 json = "0.12.4"
 metriken = "0.1.0"
 mio = { version = "0.8.4", features = ["os-poll", "net"] }

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -175,7 +175,7 @@ pub struct General {
     admin: Option<String>,
 
     #[serde(default)]
-    output_format: OutputFormat
+    output_format: OutputFormat,
 }
 
 impl General {

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -143,6 +143,23 @@ pub enum Protocol {
     ThriftCache,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+pub enum OutputFormat {
+    /// Output resulting statistics via log messages. This is the default.
+    Log,
+
+    /// Output statistics as JSON messages on stdout.
+    Json,
+}
+
+impl Default for OutputFormat {
+    fn default() -> Self {
+        Self::Log
+    }
+}
+
 #[derive(Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct General {
@@ -156,6 +173,9 @@ pub struct General {
     #[serde(default)]
     service: bool,
     admin: Option<String>,
+
+    #[serde(default)]
+    output_format: OutputFormat
 }
 
 impl General {
@@ -181,6 +201,10 @@ impl General {
 
     pub fn admin(&self) -> Option<String> {
         self.admin.clone()
+    }
+
+    pub fn output_format(&self) -> OutputFormat {
+        self.output_format
     }
 }
 


### PR DESCRIPTION
I would like to use rpc-perf for benchmarking in a script but parsing the resulting latency data out of the log messages is difficult (not to mention that you can't combine multiple runs of rpc-perf either). This PR changes rpc-perf so that it can output in both the original log format as well as a json format, with a switch in the config file to choose which one is desired. The output json also chooses to always output counts instead of rates and contains the non-zero buckets of the histogram.
