### PR TITLE
fix: off-by-one error in heatmap histogram index

### DIFF
--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -301,7 +301,7 @@ struct JsonSnapshot {
 
 // gets the non-zero buckets for the most recent window in the heatmap
 fn heatmap_to_buckets(heatmap: &Heatmap) -> RequestLatencies {
-    if let Some(histogram) = heatmap.iter().nth(60).map(|w| w.histogram()) {
+    if let Some(histogram) = heatmap.iter().nth(59).map(|w| w.histogram()) {
         let mut index = Vec::new();
         let mut count = Vec::new();
 


### PR DESCRIPTION
The heatmap is initialized with a total span of a minute with a resolution of 1s. This results in a total of 61 histograms, with 60 active and one empty one ready for writing. The iterator is initialized with the current histogram+2, i.e., skipping over the next empty histogram and pointing to the oldest completed one. Indexing 60 forward from there points to the current, live histogram, rather than the previous completed one.
