### PR TITLE
change: output histogram parameters in the JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "heatmap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5215fe8c60b67071fb8d7fe407631449641f2010152db16088c05ae00a00c2"
+checksum = "fdeff4026a4e69d8ae19b51fa661841da47c3448ba67ad44affe893a2c985e31"
 dependencies = [
  "clocksource",
  "histogram",
@@ -751,9 +751,9 @@ checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "histogram"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c9ff99982ffdd3056847e7dd1f3e6ceae8826fb0af27d91f29cb7b119820177"
+checksum = "d0978bb4ae7b21dded5037bc688271ec01443b6eb2c7713aad75fce2cf670923"
 dependencies = [
  "thiserror",
 ]
@@ -1104,9 +1104,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "metriken"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9ec8699ded843c60ea478d0c41583b447700524f93d5c74bfb1edf8347fd6d"
+checksum = "2c7be5d59844605ce7e2e1952b34a708cbc221b459247988dcde96140508bc6f"
 dependencies = [
  "clocksource",
  "heatmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ foreign-types-shared = "0.3.1"
 http-body-util = "0.1.0-rc.2"
 hyper = { version = "1.0.0-rc.3", features = ["http1", "http2", "client"]}
 momento = "0.26.2"
-metriken = "0.1.3"
+metriken = "0.1.4"
 mio = "0.8.5"
 net = { git = "https://github.com/pelikan-io/pelikan" }
 paste = "1.0.12"

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -140,7 +140,7 @@ macro_rules! heatmap {
             crate = metriken
         )]
         pub static $ident: Lazy<metriken::Heatmap> = metriken::Lazy::new(|| {
-            metriken::Heatmap::new(0, 8, 64, Duration::from_secs(60), Duration::from_secs(1)).unwrap()
+            metriken::Heatmap::new(0, 8, 64, Duration::from_secs(60), Duration::from_secs(1), None, None).unwrap()
         });
     };
     ($ident:ident, $name:tt, $description:tt) => {
@@ -150,7 +150,7 @@ macro_rules! heatmap {
             crate = metriken
         )]
         pub static $ident: Lazy<metriken::Heatmap> = metriken::Lazy::new(|| {
-            metriken::Heatmap::new(0, 8, 64, Duration::from_secs(60), Duration::from_secs(1)).unwrap()
+            metriken::Heatmap::new(0, 8, 64, Duration::from_secs(60), Duration::from_secs(1), None, None).unwrap()
         });
     };
 }


### PR DESCRIPTION
The histogram of request latencies can be reconstructed if the parameters used for minimum and maximum values and the granularity are know. Export those values along with the non-zero buckets.