### PR TITLE
fix: more accurate ratelimits

### DIFF
--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -329,7 +329,12 @@ mod handlers {
     ) -> Result<impl warp::Reply, Infallible> {
         if let Some(r) = ratelimit {
             let amount = (rate as f64 / 1_000_000.0).ceil() as u64;
-            let interval = Duration::from_micros(1_000_000 / (rate / amount));
+
+            // even though we might not have nanosecond level clock resolution,
+            // by using a nanosecond level duration, we achieve more accurate
+            // ratelimits.
+            let interval = Duration::from_nanos(1_000_000_000 / (rate / amount));
+
             let capacity = std::cmp::max(100, amount);
 
             r.set_max_tokens(capacity)

--- a/src/workload/mod.rs
+++ b/src/workload/mod.rs
@@ -70,7 +70,12 @@ impl Generator {
     pub fn new(config: &Config) -> Self {
         let ratelimiter = config.workload().ratelimit().map(|rate| {
             let amount = (rate.get() as f64 / 1_000_000.0).ceil() as u64;
-            let interval = Duration::from_micros(1_000_000 / (rate.get() / amount));
+
+            // even though we might not have nanosecond level clock resolution,
+            // by using a nanosecond level duration, we achieve more accurate
+            // ratelimits.
+            let interval = Duration::from_nanos(1_000_000_000 / (rate.get() / amount));
+
             let capacity = std::cmp::max(100, amount);
 
             Arc::new(
@@ -567,7 +572,12 @@ pub async fn reconnect(work_sender: Sender<ClientWorkItem>, config: Config) -> R
 
     let ratelimiter = config.client().unwrap().reconnect_rate().map(|rate| {
         let amount = (rate.get() as f64 / 1_000_000.0).ceil() as u64;
-        let interval = Duration::from_micros(1_000_000 / (rate.get() / amount));
+
+        // even though we might not have nanosecond level clock resolution,
+        // by using a nanosecond level duration, we achieve more accurate
+        // ratelimits.
+        let interval = Duration::from_nanos(1_000_000_000 / (rate.get() / amount));
+
         let capacity = std::cmp::max(100, amount);
 
         Arc::new(


### PR DESCRIPTION
Fixes the ratelimits to be more accurate by using nanosecond resolution refill intervals.
