### PR TITLE
fix: use logging framework instead of eprintln

### DIFF
--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -334,7 +334,7 @@ fn heatmap_to_buckets(heatmap: &Heatmap) -> RequestLatencies {
             count,
         }
     } else {
-        eprintln!("no histogram");
+        trace!("no histogram");
         RequestLatencies {
             m: 0,
             r: 0,


### PR DESCRIPTION
Fixes the output module to use the logging framework to emit the message about "no histogram" instead of using eprintln. This reduces noise when running rpc-perf with json output enabled.
