### PR TITLE
chore: refactor result handling for Momento commands

### DIFF
--- a/src/clients/momento/commands/delete.rs
+++ b/src/clients/momento/commands/delete.rs
@@ -8,23 +8,10 @@ pub async fn delete(
     request: workload::client::Delete,
 ) -> std::result::Result<(), ResponseError> {
     DELETE.increment();
-    match timeout(
+    let result = timeout(
         config.client().unwrap().request_timeout(),
         client.delete(cache_name, (*request.key).to_owned()),
     )
-    .await
-    {
-        Ok(Ok(_)) => {
-            DELETE_OK.increment();
-            Ok(())
-        }
-        Ok(Err(e)) => {
-            DELETE_EX.increment();
-            Err(e.into())
-        }
-        Err(_) => {
-            DELETE_TIMEOUT.increment();
-            Err(ResponseError::Timeout)
-        }
-    }
+    .await;
+    record_result!(result, DELETE)
 }

--- a/src/clients/momento/commands/hash_delete.rs
+++ b/src/clients/momento/commands/hash_delete.rs
@@ -8,7 +8,7 @@ pub async fn hash_delete(
     request: workload::client::HashDelete,
 ) -> std::result::Result<(), ResponseError> {
     HASH_DELETE.increment();
-    match timeout(
+    let result = timeout(
         config.client().unwrap().request_timeout(),
         client.dictionary_delete(
             cache_name,
@@ -16,19 +16,6 @@ pub async fn hash_delete(
             Fields::Some(request.fields.iter().map(|f| &**f).collect()),
         ),
     )
-    .await
-    {
-        Ok(Ok(_)) => {
-            HASH_DELETE_OK.increment();
-            Ok(())
-        }
-        Ok(Err(e)) => {
-            HASH_DELETE_EX.increment();
-            Err(e.into())
-        }
-        Err(_) => {
-            HASH_DELETE_TIMEOUT.increment();
-            Err(ResponseError::Timeout)
-        }
-    }
+    .await;
+    record_result!(result, HASH_DELETE)
 }

--- a/src/clients/momento/commands/hash_increment.rs
+++ b/src/clients/momento/commands/hash_increment.rs
@@ -25,7 +25,6 @@ pub async fn hash_increment(
     {
         Ok(Ok(r)) => {
             HASH_INCR_OK.increment();
-            #[allow(clippy::if_same_then_else)]
             if r.value == request.amount {
                 RESPONSE_MISS.increment();
                 HASH_INCR_MISS.increment();

--- a/src/clients/momento/commands/hash_set.rs
+++ b/src/clients/momento/commands/hash_set.rs
@@ -16,7 +16,7 @@ pub async fn hash_set(
         .iter()
         .map(|(k, v)| (k.to_vec(), v.to_vec()))
         .collect();
-    match timeout(
+    let result = timeout(
         config.client().unwrap().request_timeout(),
         client.dictionary_set(
             cache_name,
@@ -25,19 +25,6 @@ pub async fn hash_set(
             CollectionTtl::new(request.ttl, false),
         ),
     )
-    .await
-    {
-        Ok(Ok(_)) => {
-            HASH_SET_OK.increment();
-            Ok(())
-        }
-        Ok(Err(e)) => {
-            HASH_SET_EX.increment();
-            Err(e.into())
-        }
-        Err(_) => {
-            HASH_SET_TIMEOUT.increment();
-            Err(ResponseError::Timeout)
-        }
-    }
+    .await;
+    record_result!(result, HASH_SET)
 }

--- a/src/clients/momento/commands/list_fetch.rs
+++ b/src/clients/momento/commands/list_fetch.rs
@@ -8,23 +8,10 @@ pub async fn list_fetch(
     request: workload::client::ListFetch,
 ) -> std::result::Result<(), ResponseError> {
     LIST_FETCH.increment();
-    match timeout(
+    let result = timeout(
         config.client().unwrap().request_timeout(),
         client.list_fetch(cache_name, &*request.key),
     )
-    .await
-    {
-        Ok(Ok(_)) => {
-            LIST_FETCH_OK.increment();
-            Ok(())
-        }
-        Ok(Err(e)) => {
-            LIST_FETCH_EX.increment();
-            Err(e.into())
-        }
-        Err(_) => {
-            LIST_FETCH_TIMEOUT.increment();
-            Err(ResponseError::Timeout)
-        }
-    }
+    .await;
+    record_result!(result, LIST_FETCH)
 }

--- a/src/clients/momento/commands/list_length.rs
+++ b/src/clients/momento/commands/list_length.rs
@@ -8,23 +8,10 @@ pub async fn list_length(
     request: workload::client::ListLength,
 ) -> std::result::Result<(), ResponseError> {
     LIST_LENGTH.increment();
-    match timeout(
+    let result = timeout(
         config.client().unwrap().request_timeout(),
         client.list_fetch(cache_name, &*request.key),
     )
-    .await
-    {
-        Ok(Ok(_)) => {
-            LIST_LENGTH_OK.increment();
-            Ok(())
-        }
-        Ok(Err(e)) => {
-            LIST_LENGTH_EX.increment();
-            Err(e.into())
-        }
-        Err(_) => {
-            LIST_LENGTH_TIMEOUT.increment();
-            Err(ResponseError::Timeout)
-        }
-    }
+    .await;
+    record_result!(result, LIST_LENGTH)
 }

--- a/src/clients/momento/commands/list_pop_back.rs
+++ b/src/clients/momento/commands/list_pop_back.rs
@@ -8,23 +8,10 @@ pub async fn list_pop_back(
     request: workload::client::ListPopBack,
 ) -> std::result::Result<(), ResponseError> {
     LIST_POP_BACK.increment();
-    match timeout(
+    let result = timeout(
         config.client().unwrap().request_timeout(),
         client.list_pop_back(cache_name, &*request.key),
     )
-    .await
-    {
-        Ok(Ok(_)) => {
-            LIST_POP_BACK_OK.increment();
-            Ok(())
-        }
-        Ok(Err(e)) => {
-            LIST_POP_BACK_EX.increment();
-            Err(e.into())
-        }
-        Err(_) => {
-            LIST_POP_BACK_TIMEOUT.increment();
-            Err(ResponseError::Timeout)
-        }
-    }
+    .await;
+    record_result!(result, LIST_POP_BACK)
 }

--- a/src/clients/momento/commands/list_pop_front.rs
+++ b/src/clients/momento/commands/list_pop_front.rs
@@ -8,23 +8,10 @@ pub async fn list_pop_front(
     request: workload::client::ListPopFront,
 ) -> std::result::Result<(), ResponseError> {
     LIST_POP_FRONT.increment();
-    match timeout(
+    let result = timeout(
         config.client().unwrap().request_timeout(),
         client.list_pop_front(cache_name, &*request.key),
     )
-    .await
-    {
-        Ok(Ok(_)) => {
-            LIST_POP_FRONT_OK.increment();
-            Ok(())
-        }
-        Ok(Err(e)) => {
-            LIST_POP_FRONT_EX.increment();
-            Err(e.into())
-        }
-        Err(_) => {
-            LIST_POP_FRONT_TIMEOUT.increment();
-            Err(ResponseError::Timeout)
-        }
-    }
+    .await;
+    record_result!(result, LIST_POP_FRONT)
 }

--- a/src/clients/momento/commands/list_push_back.rs
+++ b/src/clients/momento/commands/list_push_back.rs
@@ -11,8 +11,8 @@ pub async fn list_push_back(
     request: workload::client::ListPushBack,
 ) -> std::result::Result<(), ResponseError> {
     LIST_PUSH_BACK.increment();
-    let result = if request.elements.len() == 1 {
-        match timeout(
+    if request.elements.len() == 1 {
+        let result = timeout(
             config.client().unwrap().request_timeout(),
             client.list_push_back(
                 cache_name,
@@ -22,17 +22,13 @@ pub async fn list_push_back(
                 CollectionTtl::new(request.ttl, false),
             ),
         )
-        .await
-        {
-            Ok(Ok(_)) => Ok(()),
-            Ok(Err(e)) => Err(e.into()),
-            Err(_) => Err(ResponseError::Timeout),
-        }
+        .await;
+        record_result!(result, LIST_PUSH_BACK)
     } else {
         // note: we need to reverse because the semantics of list
         // concat do not match the redis push semantics
         let elements: Vec<&[u8]> = request.elements.iter().map(|v| v.borrow()).rev().collect();
-        match timeout(
+        let result = timeout(
             config.client().unwrap().request_timeout(),
             client.list_concat_back(
                 cache_name,
@@ -42,24 +38,7 @@ pub async fn list_push_back(
                 CollectionTtl::new(None, false),
             ),
         )
-        .await
-        {
-            Ok(Ok(_)) => Ok(()),
-            Ok(Err(e)) => Err(e.into()),
-            Err(_) => Err(ResponseError::Timeout),
-        }
-    };
-    match result {
-        Ok(_) => {
-            LIST_PUSH_BACK_OK.increment();
-        }
-        Err(ResponseError::Timeout) => {
-            LIST_PUSH_BACK_TIMEOUT.increment();
-        }
-        Err(_) => {
-            LIST_PUSH_BACK_EX.increment();
-        }
+        .await;
+        record_result!(result, LIST_PUSH_BACK)
     }
-
-    result
 }

--- a/src/clients/momento/commands/mod.rs
+++ b/src/clients/momento/commands/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use paste::paste;
 
 mod delete;
 mod get;
@@ -47,3 +48,45 @@ pub use sorted_set_range::*;
 pub use sorted_set_rank::*;
 pub use sorted_set_remove::*;
 pub use sorted_set_score::*;
+
+#[macro_export]
+#[rustfmt::skip]
+macro_rules! record_result {
+    ($result:ident, $command:ident) => {
+        paste! {
+            match $result {
+		        Ok(Ok(_)) => {
+		            [<$command _OK>].increment();
+		            Ok(())
+		        }
+		        Ok(Err(e)) => {
+		            [<$command _EX>].increment();
+		            Err(e.into())
+		        }
+		        Err(_) => {
+		            [<$command _TIMEOUT>].increment();
+		            Err(ResponseError::Timeout)
+		        }
+		    }
+        }
+    };
+
+    ($result:ident, $command:ident, $ok:ident) => {
+        paste! {
+            match $result {
+		        Ok(Ok(_)) => {
+		            [<$ok>].increment();
+		            Ok(())
+		        }
+		        Ok(Err(e)) => {
+		            [<$command _EX>].increment();
+		            Err(e.into())
+		        }
+		        Err(_) => {
+		            [<$command _TIMEOUT>].increment();
+		            Err(ResponseError::Timeout)
+		        }
+		    }
+        }
+    };
+}

--- a/src/clients/momento/commands/set.rs
+++ b/src/clients/momento/commands/set.rs
@@ -8,7 +8,7 @@ pub async fn set(
     request: workload::client::Set,
 ) -> std::result::Result<(), ResponseError> {
     SET.increment();
-    match timeout(
+    let result = timeout(
         config.client().unwrap().request_timeout(),
         client.set(
             cache_name,
@@ -17,19 +17,6 @@ pub async fn set(
             request.ttl,
         ),
     )
-    .await
-    {
-        Ok(Ok(_)) => {
-            SET_STORED.increment();
-            Ok(())
-        }
-        Ok(Err(e)) => {
-            SET_EX.increment();
-            Err(e.into())
-        }
-        Err(_) => {
-            SET_TIMEOUT.increment();
-            Err(ResponseError::Timeout)
-        }
-    }
+    .await;
+    record_result!(result, SET, SET_STORED)
 }

--- a/src/clients/momento/commands/set_members.rs
+++ b/src/clients/momento/commands/set_members.rs
@@ -8,23 +8,10 @@ pub async fn set_members(
     request: workload::client::SetMembers,
 ) -> std::result::Result<(), ResponseError> {
     SET_MEMBERS.increment();
-    match timeout(
+    let result = timeout(
         config.client().unwrap().request_timeout(),
         client.set_fetch(cache_name, &*request.key),
     )
-    .await
-    {
-        Ok(Ok(_)) => {
-            SET_MEMBERS_OK.increment();
-            Ok(())
-        }
-        Ok(Err(e)) => {
-            SET_MEMBERS_EX.increment();
-            Err(e.into())
-        }
-        Err(_) => {
-            SET_MEMBERS_TIMEOUT.increment();
-            Err(ResponseError::Timeout)
-        }
-    }
+    .await;
+    record_result!(result, SET_MEMBERS)
 }

--- a/src/clients/momento/commands/set_remove.rs
+++ b/src/clients/momento/commands/set_remove.rs
@@ -9,23 +9,10 @@ pub async fn set_remove(
 ) -> std::result::Result<(), ResponseError> {
     SET_REMOVE.increment();
     let members: Vec<&[u8]> = request.members.iter().map(|v| v.borrow()).collect();
-    match timeout(
+    let result = timeout(
         config.client().unwrap().request_timeout(),
         client.set_remove_elements(cache_name, &*request.key, members),
     )
-    .await
-    {
-        Ok(Ok(_)) => {
-            SET_REMOVE_OK.increment();
-            Ok(())
-        }
-        Ok(Err(e)) => {
-            SET_REMOVE_EX.increment();
-            Err(e.into())
-        }
-        Err(_) => {
-            SET_REMOVE_TIMEOUT.increment();
-            Err(ResponseError::Timeout)
-        }
-    }
+    .await;
+    record_result!(result, SET_REMOVE)
 }

--- a/src/clients/momento/commands/sorted_set_add.rs
+++ b/src/clients/momento/commands/sorted_set_add.rs
@@ -15,7 +15,7 @@ pub async fn sorted_set_add(
             score: *score,
         })
         .collect();
-    match timeout(
+    let result = timeout(
         config.client().unwrap().request_timeout(),
         client.sorted_set_put(
             cache_name,
@@ -24,19 +24,6 @@ pub async fn sorted_set_add(
             CollectionTtl::new(request.ttl, false),
         ),
     )
-    .await
-    {
-        Ok(Ok(_)) => {
-            SORTED_SET_ADD_OK.increment();
-            Ok(())
-        }
-        Ok(Err(e)) => {
-            SORTED_SET_ADD_EX.increment();
-            Err(e.into())
-        }
-        Err(_) => {
-            SORTED_SET_ADD_TIMEOUT.increment();
-            Err(ResponseError::Timeout)
-        }
-    }
+    .await;
+    record_result!(result, SORTED_SET_ADD)
 }

--- a/src/clients/momento/commands/sorted_set_increment.rs
+++ b/src/clients/momento/commands/sorted_set_increment.rs
@@ -11,7 +11,7 @@ pub async fn sorted_set_increment(
     request: workload::client::SortedSetIncrement,
 ) -> std::result::Result<(), ResponseError> {
     SORTED_SET_INCR.increment();
-    match timeout(
+    let result = timeout(
         config.client().unwrap().request_timeout(),
         client.sorted_set_increment(
             cache_name,
@@ -21,19 +21,6 @@ pub async fn sorted_set_increment(
             CollectionTtl::new(request.ttl, false),
         ),
     )
-    .await
-    {
-        Ok(Ok(_)) => {
-            SORTED_SET_INCR_OK.increment();
-            Ok(())
-        }
-        Ok(Err(e)) => {
-            SORTED_SET_INCR_EX.increment();
-            Err(e.into())
-        }
-        Err(_) => {
-            SORTED_SET_INCR_TIMEOUT.increment();
-            Err(ResponseError::Timeout)
-        }
-    }
+    .await;
+    record_result!(result, SORTED_SET_INCR)
 }

--- a/src/clients/momento/commands/sorted_set_range.rs
+++ b/src/clients/momento/commands/sorted_set_range.rs
@@ -32,18 +32,5 @@ pub async fn sorted_set_range(
     )
     .await;
 
-    match result {
-        Ok(Ok(_)) => {
-            SORTED_SET_RANGE_OK.increment();
-            Ok(())
-        }
-        Ok(Err(e)) => {
-            SORTED_SET_RANGE_EX.increment();
-            Err(e.into())
-        }
-        Err(_) => {
-            SORTED_SET_RANGE_TIMEOUT.increment();
-            Err(ResponseError::Timeout)
-        }
-    }
+    record_result!(result, SORTED_SET_RANGE)
 }

--- a/src/clients/momento/commands/sorted_set_rank.rs
+++ b/src/clients/momento/commands/sorted_set_rank.rs
@@ -8,23 +8,10 @@ pub async fn sorted_set_rank(
     request: workload::client::SortedSetRank,
 ) -> std::result::Result<(), ResponseError> {
     SORTED_SET_RANK.increment();
-    match timeout(
+    let result = timeout(
         config.client().unwrap().request_timeout(),
         client.sorted_set_get_rank(cache_name, &*request.key, &*request.member),
     )
-    .await
-    {
-        Ok(Ok(_)) => {
-            SORTED_SET_RANK_OK.increment();
-            Ok(())
-        }
-        Ok(Err(e)) => {
-            SORTED_SET_RANK_EX.increment();
-            Err(e.into())
-        }
-        Err(_) => {
-            SORTED_SET_RANK_TIMEOUT.increment();
-            Err(ResponseError::Timeout)
-        }
-    }
+    .await;
+    record_result!(result, SORTED_SET_RANK)
 }

--- a/src/clients/momento/commands/sorted_set_remove.rs
+++ b/src/clients/momento/commands/sorted_set_remove.rs
@@ -9,23 +9,10 @@ pub async fn sorted_set_remove(
 ) -> std::result::Result<(), ResponseError> {
     SORTED_SET_REMOVE.increment();
     let members: Vec<&[u8]> = request.members.iter().map(|v| v.borrow()).collect();
-    match timeout(
+    let result = timeout(
         config.client().unwrap().request_timeout(),
         client.sorted_set_remove(cache_name, &*request.key, members),
     )
-    .await
-    {
-        Ok(Ok(_)) => {
-            SORTED_SET_REMOVE_OK.increment();
-            Ok(())
-        }
-        Ok(Err(e)) => {
-            SORTED_SET_REMOVE_EX.increment();
-            Err(e.into())
-        }
-        Err(_) => {
-            SORTED_SET_REMOVE_TIMEOUT.increment();
-            Err(ResponseError::Timeout)
-        }
-    }
+    .await;
+    record_result!(result, SORTED_SET_REMOVE)
 }

--- a/src/clients/momento/commands/sorted_set_score.rs
+++ b/src/clients/momento/commands/sorted_set_score.rs
@@ -9,23 +9,10 @@ pub async fn sorted_set_score(
 ) -> std::result::Result<(), ResponseError> {
     SORTED_SET_SCORE.increment();
     let members: Vec<&[u8]> = request.members.iter().map(|v| v.borrow()).collect();
-    match timeout(
+    let result = timeout(
         config.client().unwrap().request_timeout(),
         client.sorted_set_get_score(cache_name, &*request.key, members),
     )
-    .await
-    {
-        Ok(Ok(_)) => {
-            SORTED_SET_SCORE_OK.increment();
-            Ok(())
-        }
-        Ok(Err(e)) => {
-            SORTED_SET_SCORE_EX.increment();
-            Err(e.into())
-        }
-        Err(_) => {
-            SORTED_SET_SCORE_TIMEOUT.increment();
-            Err(ResponseError::Timeout)
-        }
-    }
+    .await;
+    record_result!(result, SORTED_SET_SCORE)
 }


### PR DESCRIPTION
Refactors the result handling for Momento commands by introducing
a new macro to increment the appropriate metric and transform the
result type. This reduces the duplication across commands that have
simple result handling.