### PR TITLE
Add a target_qps field to the emitted rpc-perf json

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,7 @@ fn main() {
     let workload_components = workload_generator.components().to_owned();
 
     // spawn the admin thread
-    control_runtime.spawn(admin::http(config.clone(), workload_ratelimit));
+    control_runtime.spawn(admin::http(config.clone(), workload_ratelimit.clone()));
 
     let workload_runtime =
         launch_workload(workload_generator, &config, client_sender, pubsub_sender);
@@ -140,7 +140,7 @@ fn main() {
     // launch json log output
     {
         let config = config.clone();
-        control_runtime.spawn_blocking(move || output::json(config));
+        control_runtime.spawn_blocking(move || output::json(config, workload_ratelimit.as_deref()));
     }
 
     // provide output on cli and block until run is over

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -300,6 +300,8 @@ struct Subscribers {
 struct JsonSnapshot {
     window: u64,
     elapsed: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target_qps: Option<u64>,
     client: Client,
     pubsub: Pubsub,
 }
@@ -413,6 +415,7 @@ pub fn json(config: Config) {
             let json = JsonSnapshot {
                 window: window_id,
                 elapsed,
+                target_qps: traffic_ratelimit.as_ref().map(|ratelimit| ratelimit.rate()),
                 client: Client {
                     connections,
                     requests,


### PR DESCRIPTION
This PR adds a new `target_qps` field to the emitted json.