### PR TITLE
output: update libraries and use compact histogram 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "heatmap"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8cbf90780d798f8068becac8b922ab9901af29e2406e6327c4fda70353c58fa"
+checksum = "0ff337aee5a51159480a1c9bc225f36a7d87543023aa118d5843ece2f125bccb"
 dependencies = [
  "clocksource",
  "histogram",
@@ -798,10 +798,11 @@ checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "histogram"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0978bb4ae7b21dded5037bc688271ec01443b6eb2c7713aad75fce2cf670923"
+checksum = "e673d137229619d5c2c8903b6ed5852b43636c0017ff2e66b1aafb8ccf04b80b"
 dependencies = [
+ "serde",
  "thiserror",
 ]
 
@@ -1171,12 +1172,11 @@ dependencies = [
 
 [[package]]
 name = "metriken"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283da0f4c6ea37b3d8f932e02d368f1c1f77b3072653a91a5cdef6931b6db889"
+checksum = "d081482206e965281c71f40f1899160b9578bb8f7688b7821b144a43bc3e701a"
 dependencies = [
  "heatmap",
- "histogram",
  "linkme",
  "metriken-derive 0.2.0",
  "once_cell",
@@ -1875,7 +1875,7 @@ dependencies = [
  "ahash",
  "clocksource",
  "log",
- "metriken 0.2.1",
+ "metriken 0.2.3",
  "mpmc",
 ]
 
@@ -1893,10 +1893,11 @@ dependencies = [
  "clocksource",
  "foreign-types-shared",
  "futures",
+ "histogram",
  "http-body-util",
  "humantime",
  "hyper 1.0.0-rc.3",
- "metriken 0.2.1",
+ "metriken 0.2.3",
  "mio 0.8.6",
  "momento",
  "net",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,10 @@ foreign-types-shared = "0.3.1"
 futures = "0.3.28"
 http-body-util = "0.1.0-rc.2"
 hyper = { version = "1.0.0-rc.3", features = ["http1", "http2", "client"]}
+histogram = "0.7.4"
 humantime = "2.1.0"
 momento = "0.31.0"
-metriken = "0.2.1"
+metriken = "0.2.3"
 mio = "0.8.5"
 net = { git = "https://github.com/pelikan-io/pelikan" }
 paste = "1.0.12"


### PR DESCRIPTION
The sparse histogram format used for serialization is now
available in the library so remove the local implementation
and use the library's version of the structure.