### PR TITLE
Release v5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## [Unreleased]
 
+## [5.0.1] - 2023-08-10
+
+### Added
+
+- rpc-perf can now generate zrange commands with the by_score option for both
+  the momento and redis protocols.
+
+### Changed
+
+- rpc-perf will now set TCP_NODELAY by default on all TCP connections it
+  creates.
+
+### Fixed
+
+- The default buffer size for the memcached client has been increased from 4KB
+  to 16KB.
+- Hit/miss statistics in the output json will now have their correct values
+  instead of always being 0.
+
 ## [5.0.0] - 2023-07-25
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "rpc-perf"
-version = "5.0.1-alpha.0"
+version = "5.0.1"
 dependencies = [
  "ahash",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpc-perf"
-version = "5.0.1-alpha.0"
+version = "5.0.1"
 authors = ["Brian Martin <brian@iop.systems>"]
 edition = "2021"
 description = "RPC Performance Testing"


### PR DESCRIPTION
This is a quick patch release to make the changes of #41 available. I have updated both the changelog and the version number to match.