### PR TITLE
workflow: ignore RUSTSEC-2023-0052 during audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,4 @@
+# audit config file: specify advisories to ignore
+
+[advisories]
+ignore = ["RUSTSEC-2023-0052"] # comma-separated IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]


### PR DESCRIPTION
A version of webpki included from the momento crate has
a potential DoS vulnerability. This is not a huge concern
since rpc-perf is not an externally facing taking unknown
production traffic. Ignore auditing for this vulnerability
for the time being to allow cargo audit to pass.