### PR TITLE
update metriken to replace heatmaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ dependencies = [
  "boring",
  "clocksource",
  "macros",
- "metriken",
+ "metriken 0.2.3",
  "net",
  "ringlog",
  "serde",
@@ -811,7 +811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ff337aee5a51159480a1c9bc225f36a7d87543023aa118d5843ece2f125bccb"
 dependencies = [
  "clocksource",
- "histogram",
+ "histogram 0.7.4",
  "parking_lot",
  "thiserror",
 ]
@@ -835,6 +835,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e673d137229619d5c2c8903b6ed5852b43636c0017ff2e66b1aafb8ccf04b80b"
 dependencies = [
  "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "histogram"
+version = "0.8.0"
+source = "git+https://github.com/brayniac/rustcommon?branch=metriken-histograms#7f469354734ed4a4b5d0397da022f0568f0b9255"
+dependencies = [
  "thiserror",
 ]
 
@@ -1181,7 +1189,20 @@ checksum = "d081482206e965281c71f40f1899160b9578bb8f7688b7821b144a43bc3e701a"
 dependencies = [
  "heatmap",
  "linkme",
- "metriken-derive",
+ "metriken-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell",
+ "parking_lot",
+ "phf",
+]
+
+[[package]]
+name = "metriken"
+version = "0.2.4"
+source = "git+https://github.com/brayniac/rustcommon?branch=metriken-histograms#7f469354734ed4a4b5d0397da022f0568f0b9255"
+dependencies = [
+ "histogram 0.8.0",
+ "linkme",
+ "metriken-derive 0.2.0 (git+https://github.com/brayniac/rustcommon?branch=metriken-histograms)",
  "once_cell",
  "parking_lot",
  "phf",
@@ -1192,6 +1213,17 @@ name = "metriken-derive"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0213a7a12e01c66357d1f3491e2d7d74b2373540ea0a4bfd928a4c0e5e02f432"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "metriken-derive"
+version = "0.2.0"
+source = "git+https://github.com/brayniac/rustcommon?branch=metriken-histograms#7f469354734ed4a4b5d0397da022f0568f0b9255"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1355,7 +1387,7 @@ dependencies = [
  "boring-sys",
  "foreign-types-shared",
  "libc",
- "metriken",
+ "metriken 0.2.3",
  "mio 0.8.8",
 ]
 
@@ -1693,7 +1725,7 @@ source = "git+https://github.com/pelikan-io/pelikan#294b67991cd14c8362bd7aa9b688
 dependencies = [
  "common",
  "logger",
- "metriken",
+ "metriken 0.2.3",
  "nom",
  "protocol-common",
 ]
@@ -1706,7 +1738,7 @@ dependencies = [
  "common",
  "config",
  "logger",
- "metriken",
+ "metriken 0.2.3",
  "protocol-common",
  "storage-types",
 ]
@@ -1862,7 +1894,7 @@ dependencies = [
  "ahash",
  "clocksource",
  "log",
- "metriken",
+ "metriken 0.2.3",
  "mpmc",
 ]
 
@@ -1880,11 +1912,11 @@ dependencies = [
  "clocksource",
  "foreign-types-shared",
  "futures",
- "histogram",
+ "histogram 0.8.0",
  "http-body-util",
  "humantime",
  "hyper 1.0.0-rc.4",
- "metriken",
+ "metriken 0.2.4",
  "mio 0.8.8",
  "momento",
  "net",
@@ -1914,7 +1946,7 @@ dependencies = [
 name = "rpcperf-dataspec"
 version = "0.1.1"
 dependencies = [
- "histogram",
+ "histogram 0.8.0",
  "serde",
 ]
 
@@ -2102,7 +2134,7 @@ dependencies = [
  "bytes 1.4.0",
  "common",
  "log",
- "metriken",
+ "metriken 0.2.3",
  "net",
  "protocol-common",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ repository = { workspace = true }
 license = { workspace = true }
 
 [workspace.dependencies]
-histogram = "0.7.4"
-serde = "1.0.185"
+histogram = { git = "https://github.com/brayniac/rustcommon", branch = "metriken-histograms" }
+serde = { version = "1.0.185", features = ["derive"] }
 
 [dependencies]
 ahash = "0.8.3"
@@ -35,7 +35,7 @@ hyper = { version = "1.0.0-rc.4", features = ["http1", "http2", "client"]}
 histogram = { workspace = true }
 humantime = "2.1.0"
 momento = "0.31.0"
-metriken = "0.2.3"
+metriken = { git = "https://github.com/brayniac/rustcommon", branch = "metriken-histograms" }
 mio = "0.8.8"
 net = { git = "https://github.com/pelikan-io/pelikan" }
 paste = "1.0.14"

--- a/lib/dataspec/src/lib.rs
+++ b/lib/dataspec/src/lib.rs
@@ -2,6 +2,7 @@
 //! by any consumer of the produced data to parse the files.
 
 pub mod histogram;
+// use ::histogram::Snapshot;
 pub use crate::histogram::Histogram;
 
 use serde::{Deserialize, Serialize};
@@ -49,7 +50,7 @@ pub struct ClientStats {
     pub connections: Connections,
     pub requests: Requests,
     pub responses: Responses,
-    pub request_latency: Histogram,
+    pub response_latency: Histogram,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/clients/http1.rs
+++ b/src/clients/http1.rs
@@ -37,7 +37,7 @@ async fn task(work_receiver: Receiver<WorkItem>, endpoint: String, config: Confi
             if session_requests != 0 {
                 let stop = Instant::now();
                 let lifecycle_ns = (stop - session_start).as_nanos();
-                let _ = SESSION_LIFECYCLE_REQUESTS.increment(stop, lifecycle_ns);
+                let _ = SESSION_LIFECYCLE_REQUESTS.increment(lifecycle_ns);
             }
             CONNECT.increment();
             let stream = match timeout(
@@ -168,8 +168,7 @@ async fn task(work_receiver: Receiver<WorkItem>, endpoint: String, config: Confi
 
                 let latency = stop.duration_since(start).as_nanos();
 
-                let _ = REQUEST_LATENCY.increment(start, latency);
-                let _ = RESPONSE_LATENCY.increment(stop, latency);
+                let _ = RESPONSE_LATENCY.increment(latency);
 
                 if let Some(header) = response
                     .headers()

--- a/src/clients/http2.rs
+++ b/src/clients/http2.rs
@@ -233,8 +233,7 @@ async fn task(
 
                 let latency = stop.duration_since(start).as_nanos();
 
-                let _ = REQUEST_LATENCY.increment(start, latency);
-                let _ = RESPONSE_LATENCY.increment(stop, latency);
+                let _ = RESPONSE_LATENCY.increment(latency);
 
                 if let Some(header) = response
                     .headers()

--- a/src/clients/memcache/mod.rs
+++ b/src/clients/memcache/mod.rs
@@ -165,8 +165,7 @@ async fn task(work_receiver: Receiver<WorkItem>, endpoint: String, config: Confi
                     // increment success stats and latency
                     RESPONSE_OK.increment();
 
-                    let _ = REQUEST_LATENCY.increment(start, latency_ns);
-                    let _ = RESPONSE_LATENCY.increment(stop, latency_ns);
+                    let _ = RESPONSE_LATENCY.increment(latency_ns);
 
                     // preserve the connection for the next request
                     stream = Some(s);

--- a/src/clients/momento/mod.rs
+++ b/src/clients/momento/mod.rs
@@ -172,8 +172,7 @@ async fn task(
 
                 let latency = stop.duration_since(start).as_nanos();
 
-                let _ = REQUEST_LATENCY.increment(start, latency);
-                let _ = RESPONSE_LATENCY.increment(stop, latency);
+                let _ = RESPONSE_LATENCY.increment(latency);
             }
             Err(ResponseError::Exception) => {
                 RESPONSE_EX.increment();

--- a/src/clients/ping.rs
+++ b/src/clients/ping.rs
@@ -167,8 +167,7 @@ async fn task(work_receiver: Receiver<WorkItem>, endpoint: String, config: Confi
 
                 let latency = stop.duration_since(start).as_nanos();
 
-                let _ = REQUEST_LATENCY.increment(start, latency);
-                let _ = RESPONSE_LATENCY.increment(stop, latency);
+                let _ = RESPONSE_LATENCY.increment(latency);
             }
             Err(ResponseError::Exception) => {
                 // record execption

--- a/src/clients/redis/mod.rs
+++ b/src/clients/redis/mod.rs
@@ -167,8 +167,7 @@ async fn task(work_receiver: Receiver<WorkItem>, endpoint: String, config: Confi
                 connection = Some(con);
                 RESPONSE_OK.increment();
 
-                let _ = REQUEST_LATENCY.increment(start, latency_ns);
-                let _ = RESPONSE_LATENCY.increment(stop, latency_ns);
+                let _ = RESPONSE_LATENCY.increment(latency_ns);
             }
             Err(ResponseError::Exception) => {
                 CONNECT_CURR.decrement();

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use backtrace::Backtrace;
 use clap::{Arg, Command};
 use core::sync::atomic::{AtomicBool, Ordering};
 use core::time::Duration;
-use metriken::{Counter, Gauge, Heatmap};
+use metriken::{Counter, Gauge, AtomicHistogram};
 use ringlog::*;
 use std::collections::HashMap;
 use tokio::runtime::Builder;

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -131,12 +131,9 @@ macro_rules! heatmap {
             name = $name,
             crate = metriken
         )]
-        pub static $ident: metriken::Heatmap = metriken::Heatmap::new(
-            0,
-            8,
+        pub static $ident: metriken::AtomicHistogram = metriken::AtomicHistogram::new(
+            7,
             64,
-            core::time::Duration::from_secs(60),
-            core::time::Duration::from_secs(1),
         );
     };
     ($ident:ident, $name:tt, $description:tt) => {
@@ -145,12 +142,9 @@ macro_rules! heatmap {
             description = $description,
             crate = metriken
         )]
-        pub static $ident: metriken::Heatmap = metriken::Heatmap::new(
-            0,
-            8,
+        pub static $ident: metriken::AtomicHistogram = metriken::AtomicHistogram::new(
+            7,
             64,
-            core::time::Duration::from_secs(60),
-            core::time::Duration::from_secs(1),
         );
     };
 }
@@ -204,15 +198,9 @@ macro_rules! request {
 }
 
 heatmap!(
-    REQUEST_LATENCY,
-    "request_latency",
-    "distribution of request latencies in nanoseconds. incremented at time of requests disbatch."
-);
-
-heatmap!(
     RESPONSE_LATENCY,
     "response_latency",
-    "distribution of response latencies in nanoseconds. incremented at time of response receipt."
+    "distribution of response latencies in nanoseconds."
 );
 
 heatmap!(

--- a/src/pubsub/momento.rs
+++ b/src/pubsub/momento.rs
@@ -91,7 +91,6 @@ async fn subscriber_task(client: Arc<TopicClient>, cache_name: String, topic: St
             match subscription.next().await {
                 Some(SubscriptionItem::Value(v)) => {
                     if let ValueKind::Binary(mut v) = v.kind {
-                        let now = Instant::now();
                         let now_unix = UnixInstant::now();
 
                         if [v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7]]
@@ -121,9 +120,8 @@ async fn subscriber_task(client: Arc<TopicClient>, cache_name: String, topic: St
                         ]);
 
                         let latency = now_unix - UnixInstant::from_nanos(ts);
-                        let then = now - latency;
 
-                        let _ = PUBSUB_LATENCY.increment(then, latency.as_nanos());
+                        let _ = PUBSUB_LATENCY.increment(latency.as_nanos());
 
                         PUBSUB_RECEIVE.increment();
                         PUBSUB_RECEIVE_OK.increment();
@@ -286,7 +284,7 @@ async fn publisher_task(
                 let latency = stop.duration_since(start).as_nanos();
 
                 PUBSUB_PUBLISH_OK.increment();
-                let _ = PUBSUB_PUBLISH_LATENCY.increment(start, latency);
+                let _ = PUBSUB_PUBLISH_LATENCY.increment(latency);
             }
             Err(ResponseError::Exception) => {
                 PUBSUB_PUBLISH_EX.increment();


### PR DESCRIPTION
Updates metriken library to replace heatmaps with histograms which have better runtime performance characteristics and lower memory footprint.

