### PR TITLE
change dependabot versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,6 @@ updates:
         patterns:
           - "*"
     open-pull-requests-limit: 10
-    versioning-strategy: auto
+    versioning-strategy: lockfile-only
     allow:
       - dependency-type: all


### PR DESCRIPTION
Change dependabot versioning strategy to lockfile-only to avoid breaking updates for 0.x versioned crates.
