### PR TITLE
chore: update ubuntu releases for packaging workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -51,8 +51,8 @@ jobs:
           - { distro: ubuntu, release: bionic  } # LTS until Apr 2028
           - { distro: ubuntu, release: focal   } # LTS until Apr 2030
           - { distro: ubuntu, release: jammy   } # LTS until Apr 2032
-          - { distro: ubuntu, release: kinetic } # Previous release
-          - { distro: ubuntu, release: lunar   } # Current release
+          - { distro: ubuntu, release: lunar } # Previous release
+          - { distro: ubuntu, release: mantic   } # Current release
       fail-fast: false
     env:
       # dpkg-buildpackage issues a warning if we attempt to cross compile and


### PR DESCRIPTION
Update the ubuntu releases for the packaging workflow

Fixes #67 