### PR TITLE
kafka: use different group id for each client

### DIFF
--- a/configs/kafka.toml
+++ b/configs/kafka.toml
@@ -68,6 +68,9 @@ weight = 1
 # the total number of Kafka consumer clients for topics in this compoment
 subscriber_poolsize = 1
 # the total number of Kafka tasks per Kafka consumer client
+# NOTE: received messages will not fanout to all tasks per client. To compare
+# with other pubsub implementations, set the concurrency to `1` and increase the
+# poolsize instead.
 subscriber_concurrency = 2
 # the number of topics
 topics = 2

--- a/src/pubsub/kafka.rs
+++ b/src/pubsub/kafka.rs
@@ -137,16 +137,15 @@ pub fn launch_subscribers(
     config: Config,
     workload_components: &[Component],
 ) {
-    let group_id = "rpc_subscriber";
     for component in workload_components {
         if let Component::Topics(topics) = component {
             let poolsize = topics.subscriber_poolsize();
             let concurrency = topics.subscriber_concurrency();
 
-            for _ in 0..poolsize {
+            for id in 0..poolsize {
                 let client = {
                     let _guard = runtime.enter();
-                    Arc::new(get_kafka_consumer(&config, group_id))
+                    Arc::new(get_kafka_consumer(&config, &format!("rpcperf_subscriber_{id}")))
                 };
                 for _ in 0..concurrency {
                     let mut sub_topics: Vec<String> = Vec::new();

--- a/src/pubsub/kafka.rs
+++ b/src/pubsub/kafka.rs
@@ -145,7 +145,10 @@ pub fn launch_subscribers(
             for id in 0..poolsize {
                 let client = {
                     let _guard = runtime.enter();
-                    Arc::new(get_kafka_consumer(&config, &format!("rpcperf_subscriber_{id}")))
+                    Arc::new(get_kafka_consumer(
+                        &config,
+                        &format!("rpcperf_subscriber_{id}"),
+                    ))
                 };
                 for _ in 0..concurrency {
                     let mut sub_topics: Vec<String> = Vec::new();


### PR DESCRIPTION
Previously, by using a fixed group id for all kafka clients, there was no fanout of published messages. This differs from the behavior of Momento Topics and Redis PubSub.

In order to make the behavior similar to other pubsub systems, we set a unique group id per client so that each client receives all published messages.
