### PR TITLE
Derive `utoipa::ToSchema` for all dataspec types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,6 +1015,7 @@ checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.1",
+ "serde",
 ]
 
 [[package]]
@@ -1643,6 +1644,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1965,6 +1990,7 @@ dependencies = [
  "histogram",
  "serde",
  "thiserror",
+ "utoipa",
 ]
 
 [[package]]
@@ -2704,6 +2730,30 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "utoipa"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ff05e3bac2c9428f57ade702667753ca3f5cf085e2011fe697de5bfd49aa72d"
+dependencies = [
+ "indexmap 2.0.2",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0b6f4667edd64be0e820d6631a60433a269710b6ee89ac39525b872b76d61d"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
 
 [[package]]
 name = "vcpkg"

--- a/lib/dataspec/Cargo.toml
+++ b/lib/dataspec/Cargo.toml
@@ -7,7 +7,14 @@ homepage = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
 
+[features]
+utoipa = [ "dep:utoipa" ]
+
 [dependencies]
 histogram = { workspace = true }
 serde = { workspace = true }
 thiserror = "1.0.47"
+
+[dependencies.utoipa]
+version = "4.1.0"
+optional = true

--- a/lib/dataspec/src/lib.rs
+++ b/lib/dataspec/src/lib.rs
@@ -4,6 +4,8 @@ use histogram::SparseHistogram;
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "utoipa", schema(as = rpcperf_dataspec::Connections))]
 pub struct Connections {
     /// number of current connections (gauge)
     pub current: i64,
@@ -18,6 +20,8 @@ pub struct Connections {
 }
 
 #[derive(Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "utoipa", schema(as = rpcperf_dataspec::Requests))]
 pub struct Requests {
     pub total: u64,
     pub ok: u64,
@@ -26,6 +30,8 @@ pub struct Requests {
 }
 
 #[derive(Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "utoipa", schema(as = rpcperf_dataspec::Responses))]
 pub struct Responses {
     /// total number of responses
     pub total: u64,
@@ -42,6 +48,8 @@ pub struct Responses {
 }
 
 #[derive(Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "utoipa", schema(as = rpcperf_dataspec::ClientStats))]
 pub struct ClientStats {
     pub connections: Connections,
     pub requests: Requests,
@@ -51,24 +59,32 @@ pub struct ClientStats {
 }
 
 #[derive(Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "utoipa", schema(as = rpcperf_dataspec::PubsubStats))]
 pub struct PubsubStats {
     pub publishers: Publishers,
     pub subscribers: Subscribers,
 }
 
 #[derive(Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "utoipa", schema(as = rpcperf_dataspec::Publishers))]
 pub struct Publishers {
     // current number of publishers
     pub current: i64,
 }
 
 #[derive(Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "utoipa", schema(as = rpcperf_dataspec::Subscribers))]
 pub struct Subscribers {
     // current number of subscribers
     pub current: i64,
 }
 
 #[derive(Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "utoipa", schema(as = rpcperf_dataspec::JsonSnapshot))]
 pub struct JsonSnapshot {
     pub window: u64,
     pub elapsed: f64,


### PR DESCRIPTION
I am trying to make the systemslab OpenAPI schema both valid and complete. rpcperf_dataspec does not have any schema annotations so this commit adds them.

All this is blocked behind a utoipa feature on rpcperf-dataspec so it does not get enabled by default.