### PR TITLE
make sure git is available during packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,8 @@ Build-Depends:
  clang:native,
  protobuf-compiler,
  cmake,
- libstdc++6
+ libstdc++6,
+ git
 # Note the libstd++6 dependency is to pull in dependencies that are needed when
 # identifying the shlib deps of the rpc-perf binary.
 


### PR DESCRIPTION
Updates the control file to make sure that git is available during packaging
