### PR TITLE
add blabber protocol support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
 
 [[package]]
 name = "async-channel"
@@ -138,18 +138,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.42",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.74"
+version = "0.1.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "fdf6721fb0140e4f897002dd086c06f6c27775df19cfe1fccb21181a48fd2c98"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -169,9 +169,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes 1.5.0",
  "futures-util",
- "http",
+ "http 0.2.11",
  "http-body 0.4.6",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -195,7 +195,7 @@ dependencies = [
  "async-trait",
  "bytes 1.5.0",
  "futures-util",
- "http",
+ "http 0.2.11",
  "http-body 0.4.6",
  "mime",
  "rustversion",
@@ -226,9 +226,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "bindgen"
@@ -247,7 +247,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.38",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -448,13 +448,12 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#db11f2ae4fc30a6b36e04a042f0d23d2eecd48e7"
+source = "git+https://github.com/pelikan-io/pelikan#3ce36a45215a013e4be2134e7b3b6f3aa0d5dfab"
 dependencies = [
  "boring",
  "clocksource",
- "macros",
  "metriken",
- "net",
+ "pelikan-net 0.1.0 (git+https://github.com/pelikan-io/pelikan)",
  "ringlog",
  "serde",
 ]
@@ -471,7 +470,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#db11f2ae4fc30a6b36e04a042f0d23d2eecd48e7"
+source = "git+https://github.com/pelikan-io/pelikan#3ce36a45215a013e4be2134e7b3b6f3aa0d5dfab"
 dependencies = [
  "common",
  "log",
@@ -508,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+checksum = "c06d96137f14f244c37f989d9fff8f95e6c18b918e71f36638f8c49112e4c78f"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -601,7 +600,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -707,7 +706,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -784,8 +783,27 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
- "indexmap 2.0.2",
+ "http 0.2.11",
+ "indexmap 2.1.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d308f63daf4181410c242d34c11f928dcb3aa105852019e043c9d1f4e4368a"
+dependencies = [
+ "bytes 1.5.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.0.0",
+ "indexmap 2.1.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -800,9 +818,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "headers"
@@ -810,10 +828,10 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
  "bytes 1.5.0",
  "headers-core",
- "http",
+ "http 0.2.11",
  "httpdate",
  "mime",
  "sha1",
@@ -825,7 +843,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.11",
 ]
 
 [[package]]
@@ -856,36 +874,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes 1.5.0",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes 1.5.0",
- "http",
+ "http 0.2.11",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "http-body"
-version = "1.0.0-rc.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951dfc2e32ac02d67c90c0d65bd27009a635dc9b381a2cc7d284ab01e3a0150d"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes 1.5.0",
- "http",
+ "http 1.0.0",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ef12f041acdd397010e5fb6433270c147d3b8b2d0a840cd7fff8e531dca5c8"
+checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
 dependencies = [
  "bytes 1.5.0",
  "futures-util",
- "http",
- "http-body 1.0.0-rc.2",
+ "http 1.0.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -909,22 +938,22 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes 1.5.0",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
+ "h2 0.3.22",
+ "http 0.2.11",
  "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -933,22 +962,20 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.0.0-rc.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d280a71f348bcc670fc55b02b63c53a04ac0bf2daff2980795aeaf53edae10e6"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
 dependencies = [
  "bytes 1.5.0",
  "futures-channel",
  "futures-util",
- "h2",
- "http",
- "http-body 1.0.0-rc.2",
+ "h2 0.4.0",
+ "http 1.0.0",
+ "http-body 1.0.0",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
  "tokio",
- "tracing",
  "want",
 ]
 
@@ -958,7 +985,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1009,12 +1036,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
@@ -1066,7 +1093,7 @@ version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
  "pem",
  "ring 0.16.20",
  "serde",
@@ -1132,22 +1159,22 @@ dependencies = [
 
 [[package]]
 name = "linkme"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e6b0bb9ca88d3c5ae88240beb9683821f903b824ee8381ef9ab4e8522fbfa9"
+checksum = "d3ae8aae8e1d516e0a3ceee1219eded7f73741607e4227bf11ef2c3e31580427"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b3f61e557a617ec6ba36c79431e1f3b5e100d67cfbdb61ed6ef384298af016"
+checksum = "ad083d767be37e709a232ae2a244445ed032bb9c6bf7d9442dd416ba5a7b7264"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -1169,7 +1196,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 [[package]]
 name = "logger"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#db11f2ae4fc30a6b36e04a042f0d23d2eecd48e7"
+source = "git+https://github.com/pelikan-io/pelikan#3ce36a45215a013e4be2134e7b3b6f3aa0d5dfab"
 dependencies = [
  "common",
  "config",
@@ -1183,16 +1210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "macros"
-version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#db11f2ae4fc30a6b36e04a042f0d23d2eecd48e7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.38",
 ]
 
 [[package]]
@@ -1325,10 +1342,10 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28ff818ee9c88dd6488b888f3f7fa16fdc63f980f564e8083c5a21ce5cfc1cb3"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
  "futures",
- "h2",
- "hyper 0.14.27",
+ "h2 0.3.22",
+ "hyper 0.14.28",
  "jsonwebtoken",
  "log",
  "momento-protos",
@@ -1365,26 +1382,13 @@ dependencies = [
  "bytes 1.5.0",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 0.2.11",
  "httparse",
  "log",
  "memchr",
  "mime",
  "spin 0.9.8",
  "version_check",
-]
-
-[[package]]
-name = "net"
-version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#db11f2ae4fc30a6b36e04a042f0d23d2eecd48e7"
-dependencies = [
- "boring",
- "boring-sys",
- "foreign-types-shared",
- "libc",
- "metriken",
- "mio 0.8.10",
 ]
 
 [[package]]
@@ -1527,6 +1531,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "pelikan-net"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b120fd5d897107cb459176e5db0dd409056b11848accd0f4dcfc690b8bdac9b3"
+dependencies = [
+ "boring",
+ "boring-sys",
+ "foreign-types-shared",
+ "libc",
+ "metriken",
+ "mio 0.8.10",
+]
+
+[[package]]
+name = "pelikan-net"
+version = "0.1.0"
+source = "git+https://github.com/pelikan-io/pelikan#3ce36a45215a013e4be2134e7b3b6f3aa0d5dfab"
+dependencies = [
+ "boring",
+ "boring-sys",
+ "foreign-types-shared",
+ "libc",
+ "metriken",
+ "mio 0.8.10",
+]
+
+[[package]]
 name = "pem"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,7 +1602,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -1600,7 +1631,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -1617,9 +1648,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "powerfmt"
@@ -1669,9 +1700,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
  "unicode-ident",
 ]
@@ -1696,13 +1727,13 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.42",
 ]
 
 [[package]]
 name = "protocol-common"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#db11f2ae4fc30a6b36e04a042f0d23d2eecd48e7"
+source = "git+https://github.com/pelikan-io/pelikan#3ce36a45215a013e4be2134e7b3b6f3aa0d5dfab"
 dependencies = [
  "bytes 1.5.0",
  "common",
@@ -1714,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "protocol-memcache"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#db11f2ae4fc30a6b36e04a042f0d23d2eecd48e7"
+source = "git+https://github.com/pelikan-io/pelikan#3ce36a45215a013e4be2134e7b3b6f3aa0d5dfab"
 dependencies = [
  "common",
  "logger",
@@ -1726,7 +1757,7 @@ dependencies = [
 [[package]]
 name = "protocol-ping"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#db11f2ae4fc30a6b36e04a042f0d23d2eecd48e7"
+source = "git+https://github.com/pelikan-io/pelikan#3ce36a45215a013e4be2134e7b3b6f3aa0d5dfab"
 dependencies = [
  "common",
  "config",
@@ -1912,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.5"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
 dependencies = [
  "cc",
  "getrandom",
@@ -1954,13 +1985,13 @@ dependencies = [
  "histogram",
  "http-body-util",
  "humantime",
- "hyper 1.0.0-rc.4",
+ "hyper 1.1.0",
  "metriken",
  "mio 0.8.10",
  "momento",
- "net",
  "once_cell",
  "paste",
+ "pelikan-net 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protocol-memcache",
  "protocol-ping",
  "rand",
@@ -2012,7 +2043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
- "ring 0.17.5",
+ "ring 0.17.7",
  "rustls-webpki",
  "sct",
 ]
@@ -2035,7 +2066,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
 ]
 
 [[package]]
@@ -2044,7 +2075,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.5",
+ "ring 0.17.7",
  "untrusted 0.9.0",
 ]
 
@@ -2087,7 +2118,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.5",
+ "ring 0.17.7",
  "untrusted 0.9.0",
 ]
 
@@ -2131,7 +2162,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -2147,9 +2178,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
 ]
@@ -2169,13 +2200,13 @@ dependencies = [
 [[package]]
 name = "session"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#db11f2ae4fc30a6b36e04a042f0d23d2eecd48e7"
+source = "git+https://github.com/pelikan-io/pelikan#3ce36a45215a013e4be2134e7b3b6f3aa0d5dfab"
 dependencies = [
  "bytes 1.5.0",
  "common",
  "log",
  "metriken",
- "net",
+ "pelikan-net 0.1.0 (git+https://github.com/pelikan-io/pelikan)",
  "protocol-common",
 ]
 
@@ -2296,7 +2327,7 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 [[package]]
 name = "storage-types"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#db11f2ae4fc30a6b36e04a042f0d23d2eecd48e7"
+source = "git+https://github.com/pelikan-io/pelikan#3ce36a45215a013e4be2134e7b3b6f3aa0d5dfab"
 
 [[package]]
 name = "strsim"
@@ -2317,9 +2348,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "5b7d0a2c048d661a1a59fcd7355baa232f7ed34e0ee4df2eef3c1c1c0d3852d8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2334,29 +2365,29 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.42",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
 dependencies = [
  "deranged",
  "itoa",
@@ -2374,9 +2405,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
 dependencies = [
  "time-core",
 ]
@@ -2398,9 +2429,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.0"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
  "backtrace",
  "bytes 1.5.0",
@@ -2444,7 +2475,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -2521,7 +2552,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "toml_datetime",
  "winnow",
 ]
@@ -2532,7 +2563,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2548,12 +2579,12 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.4",
+ "base64 0.21.5",
  "bytes 1.5.0",
- "h2",
- "http",
+ "h2 0.3.22",
+ "http 0.2.11",
  "http-body 0.4.6",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -2623,7 +2654,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -2650,7 +2681,7 @@ dependencies = [
  "byteorder",
  "bytes 1.5.0",
  "data-encoding",
- "http",
+ "http 0.2.11",
  "httparse",
  "log",
  "rand",
@@ -2737,7 +2768,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ff05e3bac2c9428f57ade702667753ca3f5cf085e2011fe697de5bfd49aa72d"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -2752,7 +2783,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -2786,8 +2817,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "headers",
- "http",
- "hyper 0.14.27",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "log",
  "mime",
  "mime_guess",
@@ -2834,7 +2865,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.42",
  "wasm-bindgen-shared",
 ]
 
@@ -2856,7 +2887,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.42",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3060,9 +3091,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.26"
+version = "0.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67b5f0a4e7a27a64c651977932b9dc5667ca7fc31ac44b03ed37a0cf42fdfff"
+checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
 dependencies = [
  "memchr",
 ]
@@ -3079,22 +3110,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.30"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306dca4455518f1f31635ec308b6b3e4eb1b11758cefafc782827d0aa7acb5c7"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.30"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be912bf68235a88fbefd1b73415cb218405958d1655b2ece9035a19920bdf6ba"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.42",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ hyper = { version = "1.0.0-rc.4", features = ["http1", "http2", "client"]}
 metriken = "0.3.3"
 mio = "0.8.8"
 momento = "0.32.1"
-net = { git = "https://github.com/pelikan-io/pelikan" }
+pelikan-net = "0.1.0"
 once_cell = "1.18.0"
 paste = "1.0.14"
 protocol-memcache = { git = "https://github.com/pelikan-io/pelikan" }

--- a/configs/blabber.toml
+++ b/configs/blabber.toml
@@ -1,0 +1,58 @@
+# An example configuration for a Pelikan Blabber client which is unidirectional
+# publishing of small messages to all clients.
+
+[general]
+# specify the protocol to be used
+protocol = "blabber"
+# the interval for stats integration and reporting
+interval = 1
+# the number of intervals to run the test for
+duration = 300
+# optionally, we can write some detailed stats to a file during the run
+#json_output = "stats.json"
+# run the admin thread with a HTTP listener at the address provided, this allows
+# stats exposition via HTTP
+admin = "127.0.0.1:9090"
+# optionally, set an initial seed for the PRNGs used to generate the workload.
+# The default is to intialize from the OS entropy pool.
+#initial_seed = "0"
+
+[debug]
+# choose from: error, warn, info, debug, trace
+log_level = "info"
+# optionally, log to the file below instead of standard out
+# log_file = "rpc-perf.log"
+# backup file name for use with log rotation
+log_backup = "rpc-perf.log.old"
+# trigger log rotation when the file grows beyond this size (in bytes). Set this
+# option to '0' to disable log rotation.
+log_max_size = 1073741824
+
+[target]
+# specify one or more endpoints as IP:PORT pairs
+endpoints = ["127.0.0.1:12321"]
+
+[pubsub]
+# the connect timeout in milliseconds
+connect_timeout = 10000
+publish_timeout = 1000
+publisher_threads = 1
+subscriber_threads = 6
+publisher_poolsize = 1
+publisher_concurrency = 20
+
+[workload]
+# the number of threads that will be used to generate requests
+threads = 1
+# the global ratelimit
+ratelimit = 1
+
+# An example set of topics using a low number of subscribers per topic.
+[[workload.topics]]
+topics = 1
+topic_len = 1
+message_len = 64
+weight = 1
+# the total number of clients that will subscribe to this set of topics
+subscriber_poolsize = 100
+

--- a/configs/momento_pubsub.toml
+++ b/configs/momento_pubsub.toml
@@ -1,7 +1,5 @@
 # An example configuration for benchmarking Momento (https://www.gomomento.com)
-# and demonstrating the use of the preview functionality for collections. Each
-# command family is using its own keyspace and covers key-value, hash, list,
-# set, and sorted set.
+# and demonstrating how to use RPC-Perf with Momento Topics (pubsub).
 
 [general]
 # specify the protocol to be used
@@ -55,6 +53,8 @@ ratelimit = 10
 [[workload.topics]]
 # the weight relative to other workload components
 weight = 1
+# limits the rate at which new subscribers are created (secondly rate)
+# subscribe_ratelimt = 1
 # the total number of Momento clients for subscribers to this set of topics
 subscriber_poolsize = 1
 # the total number of gRPC sessions per Momento client for this set of topics
@@ -70,6 +70,8 @@ message_len = 128
 [[workload.topics]]
 # the weight relative to other workload components
 weight = 1
+# limits the rate at which new subscribers are created (secondly rate)
+# subscribe_ratelimt = 1
 # the total number of Momento clients for subscribers to this set of topics
 subscriber_poolsize = 1
 # the total number of gRPC sessions per Momento client for this set of topics

--- a/lib/dataspec/src/lib.rs
+++ b/lib/dataspec/src/lib.rs
@@ -64,6 +64,10 @@ pub struct ClientStats {
 pub struct PubsubStats {
     pub publishers: Publishers,
     pub subscribers: Subscribers,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub publish_latency: Option<SparseHistogram>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_latency: Option<SparseHistogram>,
 }
 
 #[derive(Default, Deserialize, Serialize)]

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -51,6 +51,10 @@ pub fn launch_clients(config: &Config, work_receiver: Receiver<WorkItem>) -> Opt
             error!("keyspace is not supported for the kafka protocol");
             std::process::exit(1);
         }
+        Protocol::Blabber => {
+            error!("keyspace is not supported for the blabber protocol");
+            std::process::exit(1);
+        }
     }
 
     Some(client_rt)

--- a/src/clients/ping.rs
+++ b/src/clients/ping.rs
@@ -44,7 +44,11 @@ async fn task(work_receiver: Receiver<WorkItem>, endpoint: String, config: Confi
             )
             .await
             {
-                Ok(Ok(s)) => Some(s),
+                Ok(Ok(s)) => {
+                    CONNECT_OK.increment();
+                    CONNECT_CURR.increment();
+                    Some(s)
+                }
                 Ok(Err(_)) => {
                     CONNECT_EX.increment();
                     sleep(Duration::from_millis(100)).await;

--- a/src/config/client.rs
+++ b/src/config/client.rs
@@ -1,12 +1,5 @@
 use super::*;
 
-const PAGESIZE: usize = 4096;
-const DEFAULT_BUFFER_SIZE: usize = 4 * PAGESIZE;
-
-fn default_buffer_size() -> usize {
-    DEFAULT_BUFFER_SIZE
-}
-
 #[derive(Clone, Deserialize)]
 pub struct Client {
     /// The number of connections this process will have to each endpoint.

--- a/src/config/client.rs
+++ b/src/config/client.rs
@@ -22,7 +22,7 @@ pub struct Client {
     /// It is useful to increase the sizes if you expect to send and/or receive
     /// large requests/responses as part of the workload.
     ///
-    /// The default is a single page (4KB) for each the read and write buffers.
+    /// The default is a 16KB for each the read and write buffers.
     ///
     /// Not all client implementations allow setting these values, so this is a
     /// best effort basis.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,6 +21,13 @@ pub use target::Target;
 pub use tls::Tls;
 pub use workload::{Command, Distribution, Keyspace, Topics, ValueKind, Verb, Workload};
 
+pub const PAGESIZE: usize = 4096;
+pub const DEFAULT_BUFFER_SIZE: usize = 4 * PAGESIZE;
+
+pub fn default_buffer_size() -> usize {
+    DEFAULT_BUFFER_SIZE
+}
+
 #[derive(Clone, Deserialize)]
 pub struct Config {
     general: General,

--- a/src/config/protocol.rs
+++ b/src/config/protocol.rs
@@ -3,6 +3,7 @@ use super::*;
 #[derive(Clone, Copy, Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum Protocol {
+    Blabber,
     Http1,
     Http2,
     Memcache,

--- a/src/config/pubsub.rs
+++ b/src/config/pubsub.rs
@@ -18,7 +18,7 @@ pub struct Pubsub {
     /// It is useful to increase the sizes if you expect to send and/or receive
     /// large requests/responses as part of the workload.
     ///
-    /// The default is a single page (4KB) for each the read and write buffers.
+    /// The default is a 16KB for each the read and write buffers.
     ///
     /// Not all client implementations allow setting these values, so this is a
     /// best effort basis.

--- a/src/config/pubsub.rs
+++ b/src/config/pubsub.rs
@@ -14,6 +14,19 @@ pub struct Pubsub {
     publisher_poolsize: usize,
     publisher_concurrency: usize,
 
+    /// Specify the default sizes for the read and write buffers (in bytes).
+    /// It is useful to increase the sizes if you expect to send and/or receive
+    /// large requests/responses as part of the workload.
+    ///
+    /// The default is a single page (4KB) for each the read and write buffers.
+    ///
+    /// Not all client implementations allow setting these values, so this is a
+    /// best effort basis.
+    #[serde(default = "default_buffer_size")]
+    read_buffer_size: usize,
+    #[serde(default = "default_buffer_size")]
+    write_buffer_size: usize,
+
     // kafka specific configs
     kafka_acks: Option<String>,
     kafka_linger_ms: Option<String>,
@@ -46,6 +59,19 @@ impl Pubsub {
 
     pub fn publisher_concurrency(&self) -> usize {
         self.publisher_concurrency
+    }
+
+    pub fn read_buffer_size(&self) -> usize {
+        // rounds the read buffer size up to the next nearest multiple of the
+        // pagesize
+        ((std::cmp::max(1, self.read_buffer_size) + PAGESIZE - 1) / PAGESIZE) * PAGESIZE
+    }
+
+    #[allow(dead_code)]
+    pub fn write_buffer_size(&self) -> usize {
+        // rounds the write buffer size up to the next nearest multiple of the
+        // pagesize
+        ((std::cmp::max(1, self.write_buffer_size) + PAGESIZE - 1) / PAGESIZE) * PAGESIZE
     }
 
     pub fn kafka_acks(&self) -> &Option<String> {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -292,6 +292,12 @@ pub fn json(config: Config, ratelimit: Option<&Ratelimiter>) {
                     subscribers: Subscribers {
                         current: PUBSUB_SUBSCRIBER_CURR.value(),
                     },
+                    publish_latency: snapshot
+                        .histogram_delta(PUBSUB_PUBLISH_LATENCY_HISTOGRAM)
+                        .map_or_else(|| None, |h| Some(histogram::SparseHistogram::from(h))),
+                    total_latency: snapshot
+                        .histogram_delta(PUBSUB_LATENCY_HISTOGRAM)
+                        .map_or_else(|| None, |h| Some(histogram::SparseHistogram::from(h))),
                 },
             };
 

--- a/src/pubsub/blabber.rs
+++ b/src/pubsub/blabber.rs
@@ -143,30 +143,8 @@ async fn subscriber_task(endpoint: String, config: Config) -> Result<()> {
 }
 
 /// Launch tasks with one channel per task as gRPC is mux-enabled.
-pub fn launch_publishers(runtime: &mut Runtime, config: Config, work_receiver: Receiver<WorkItem>) {
-    debug!("launching blabber publisher tasks");
-
-    for _ in 0..config.pubsub().unwrap().publisher_poolsize() {
-        PUBSUB_PUBLISHER_CONNECT.increment();
-
-        // create one task per channel
-        for _ in 0..config.pubsub().unwrap().publisher_concurrency() {
-            runtime.spawn(publisher_task(work_receiver.clone()));
-        }
-    }
-}
-
-async fn publisher_task(work_receiver: Receiver<WorkItem>) -> Result<()> {
-    PUBSUB_PUBLISHER_CURR.add(1);
-
-    while RUNNING.load(Ordering::Relaxed) {
-        let _work_item = work_receiver
-            .recv()
-            .await
-            .map_err(|_| Error::new(ErrorKind::Other, "channel closed"))?;
-    }
-
-    PUBSUB_PUBLISHER_CURR.sub(1);
-
-    Ok(())
+pub fn launch_publishers(_runtime: &mut Runtime, _config: Config, _work_receiver: Receiver<WorkItem>) {
+    // note: there are no publish tasks for blabber, instead the server is
+    // expected to publish compatible messages to the subscribers
+    debug!("skipping blabber publisher tasks");
 }

--- a/src/pubsub/blabber.rs
+++ b/src/pubsub/blabber.rs
@@ -1,0 +1,172 @@
+use super::*;
+use crate::net::Connector;
+use bytes::Buf;
+use bytes::BufMut;
+use session::Buffer;
+use std::borrow::Borrow;
+use std::borrow::BorrowMut;
+use tokio::io::AsyncReadExt;
+
+use tokio::time::timeout;
+
+// blabber has a header before the standard pubsub message
+//
+//  ___________________________________
+// | 0 ..   | 4 ..    | 8 .. length    |
+// |        |         |                |
+// | length | padding | pubsub message |
+// |________|_________|________________|
+
+const HEADER_LEN: u32 = 8;
+
+/// Launch tasks with one conncetion per task as ping protocol is not mux-enabled.
+pub fn launch_subscribers(
+    runtime: &mut Runtime,
+    config: Config,
+    workload_components: &[Component],
+) {
+    debug!("launching blabber subscriber tasks");
+
+    for component in workload_components {
+        if let Component::Topics(topics) = component {
+            let connections = topics.subscriber_poolsize() * topics.subscriber_concurrency();
+
+            // create one task per "connection"
+            // note: these may be channels instead of connections for multiplexed protocols
+            for _ in 0..connections {
+                for endpoint in config.target().endpoints() {
+                    runtime.spawn(subscriber_task(endpoint.clone(), config.clone()));
+                }
+            }
+        }
+    }
+}
+
+// a task for blabber servers (eg: Pelikan Blabber)
+#[allow(clippy::slow_vector_initialization)]
+async fn subscriber_task(endpoint: String, config: Config) -> Result<()> {
+    let validator = MessageValidator::new();
+
+    let connector = Connector::new(&config)?;
+
+    // this unwrap will succeed because we wouldn't be creating these tasks if
+    // there wasn't a client config.
+    let pubsub_config = config.pubsub().unwrap();
+
+    let mut stream = None;
+    let mut read_buffer = Buffer::new(pubsub_config.read_buffer_size());
+
+    while RUNNING.load(Ordering::Relaxed) {
+        if stream.is_none() {
+            CONNECT.increment();
+            PUBSUB_SUBSCRIBE.increment();
+
+            stream = match timeout(
+                pubsub_config.connect_timeout(),
+                connector.connect(&endpoint),
+            )
+            .await
+            {
+                Ok(Ok(s)) => {
+                    CONNECT_OK.increment();
+                    CONNECT_CURR.increment();
+                    PUBSUB_SUBSCRIBER_CURR.add(1);
+                    PUBSUB_SUBSCRIBE_OK.increment();
+
+                    Some(s)
+                }
+                Ok(Err(_)) => {
+                    CONNECT_EX.increment();
+                    PUBSUB_SUBSCRIBE_EX.increment();
+
+                    sleep(Duration::from_millis(100)).await;
+                    continue;
+                }
+                Err(_) => {
+                    CONNECT_TIMEOUT.increment();
+                    PUBSUB_SUBSCRIBE_EX.increment();
+
+                    sleep(Duration::from_millis(100)).await;
+                    continue;
+                }
+            }
+        }
+
+        let mut s = stream.take().unwrap();
+
+        // read until response or timeout
+        loop {
+            match s.read(read_buffer.borrow_mut()).await {
+                Ok(n) => {
+                    unsafe {
+                        read_buffer.advance_mut(n);
+                    }
+                    {
+                        loop {
+                            let consumed = {
+                                let rbuf: &[u8] = read_buffer.borrow();
+
+                                if rbuf.len() >= HEADER_LEN as usize {
+                                    let len =
+                                        u32::from_be_bytes(rbuf[0..4].try_into().unwrap()) as usize;
+
+                                    // check if we have only a partial message
+                                    if rbuf.len() < len {
+                                        break;
+                                    }
+
+                                    let mut mbuf = rbuf[8..len].to_owned();
+
+                                    let _ = validator.validate(&mut mbuf);
+
+                                    // return the number of bytes consumed
+                                    len
+                                } else {
+                                    break;
+                                }
+                            };
+
+                            read_buffer.advance(consumed);
+                        }
+                    }
+                }
+                Err(_) => {
+                    PUBSUB_RECEIVE.increment();
+                    PUBSUB_RECEIVE_EX.increment();
+                    PUBSUB_SUBSCRIBER_CURR.sub(1);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Launch tasks with one channel per task as gRPC is mux-enabled.
+pub fn launch_publishers(runtime: &mut Runtime, config: Config, work_receiver: Receiver<WorkItem>) {
+    debug!("launching blabber publisher tasks");
+
+    for _ in 0..config.pubsub().unwrap().publisher_poolsize() {
+        PUBSUB_PUBLISHER_CONNECT.increment();
+
+        // create one task per channel
+        for _ in 0..config.pubsub().unwrap().publisher_concurrency() {
+            runtime.spawn(publisher_task(work_receiver.clone()));
+        }
+    }
+}
+
+async fn publisher_task(work_receiver: Receiver<WorkItem>) -> Result<()> {
+    PUBSUB_PUBLISHER_CURR.add(1);
+
+    while RUNNING.load(Ordering::Relaxed) {
+        let _work_item = work_receiver
+            .recv()
+            .await
+            .map_err(|_| Error::new(ErrorKind::Other, "channel closed"))?;
+    }
+
+    PUBSUB_PUBLISHER_CURR.sub(1);
+
+    Ok(())
+}

--- a/src/pubsub/blabber.rs
+++ b/src/pubsub/blabber.rs
@@ -143,7 +143,11 @@ async fn subscriber_task(endpoint: String, config: Config) -> Result<()> {
 }
 
 /// Launch tasks with one channel per task as gRPC is mux-enabled.
-pub fn launch_publishers(_runtime: &mut Runtime, _config: Config, _work_receiver: Receiver<WorkItem>) {
+pub fn launch_publishers(
+    _runtime: &mut Runtime,
+    _config: Config,
+    _work_receiver: Receiver<WorkItem>,
+) {
     // note: there are no publish tasks for blabber, instead the server is
     // expected to publish compatible messages to the subscribers
     debug!("skipping blabber publisher tasks");


### PR DESCRIPTION
Adds support for the `blabber` protocol in which the server will periodically publish messages to subscribers.

This is implemented as a pubsub protocol.

Adds latency distribution information to the dataspec for pubsub.
