### PR TITLE
feat: add internal ratelimit controller

### DIFF
--- a/configs/blabber.toml
+++ b/configs/blabber.toml
@@ -47,7 +47,7 @@ threads = 1
 
 [workload.ratelimit]
 # the global ratelimit
-ratelimit = 1
+start = 1
 
 # An example set of topics using a low number of subscribers per topic.
 [[workload.topics]]

--- a/configs/blabber.toml
+++ b/configs/blabber.toml
@@ -44,6 +44,8 @@ publisher_concurrency = 20
 [workload]
 # the number of threads that will be used to generate requests
 threads = 1
+
+[workload.ratelimit]
 # the global ratelimit
 ratelimit = 1
 

--- a/configs/http1.toml
+++ b/configs/http1.toml
@@ -86,7 +86,7 @@ threads = 1
 
 [workload.ratelimit]
 # set a global ratelimit for the workload
-ratelimit = 10_000
+start = 10_000
 
 
 [[workload.keyspace]]

--- a/configs/http1.toml
+++ b/configs/http1.toml
@@ -83,6 +83,8 @@ request_timeout = 1000
 [workload]
 # the number of threads that will be used to generate the workload
 threads = 1
+
+[workload.ratelimit]
 # set a global ratelimit for the workload
 ratelimit = 10_000
 

--- a/configs/http2.toml
+++ b/configs/http2.toml
@@ -86,7 +86,7 @@ threads = 1
 
 [workload.ratelimit]
 # set a global ratelimit for the workload
-ratelimit = 10_000
+start = 10_000
 
 
 [[workload.keyspace]]

--- a/configs/http2.toml
+++ b/configs/http2.toml
@@ -83,6 +83,8 @@ request_timeout = 1000
 [workload]
 # the number of threads that will be used to generate the workload
 threads = 1
+
+[workload.ratelimit]
 # set a global ratelimit for the workload
 ratelimit = 10_000
 

--- a/configs/kafka.toml
+++ b/configs/kafka.toml
@@ -60,7 +60,7 @@ threads = 1
 
 [workload.ratelimit]
 # the global ratelimit
-ratelimit = 1000
+start = 1000
 
 # An example set of
 #topics using a single consumer multiple producer.

--- a/configs/kafka.toml
+++ b/configs/kafka.toml
@@ -57,6 +57,8 @@ kafka_linger_ms = "1"
 [workload]
 # the number of threads that will be used to generate requests
 threads = 1
+
+[workload.ratelimit]
 # the global ratelimit
 ratelimit = 1000
 

--- a/configs/memcached.toml
+++ b/configs/memcached.toml
@@ -50,7 +50,7 @@ threads = 1
 
 [workload.ratelimit]
 # set a global ratelimit for the workload
-ratelimit = 10_000
+start = 10_000
 
 [[workload.keyspace]]
 # sets the relative weight of this keyspace: defaults to 1

--- a/configs/memcached.toml
+++ b/configs/memcached.toml
@@ -47,6 +47,8 @@ request_timeout = 1000
 [workload]
 # the number of threads that will be used to generate the workload
 threads = 1
+
+[workload.ratelimit]
 # set a global ratelimit for the workload
 ratelimit = 10_000
 

--- a/configs/momento.toml
+++ b/configs/momento.toml
@@ -55,6 +55,8 @@ request_timeout = 1000
 [workload]
 # the number of threads that will be used to generate the workload
 threads = 1
+
+[workload.ratelimit]
 # set a global ratelimit for the workload
 ratelimit = 50
 

--- a/configs/momento.toml
+++ b/configs/momento.toml
@@ -58,7 +58,7 @@ threads = 1
 
 [workload.ratelimit]
 # set a global ratelimit for the workload
-ratelimit = 50
+start = 50
 
 # An example keyspace showcasing the use of the `key-value` family of commands.
 #

--- a/configs/momento_pubsub.toml
+++ b/configs/momento_pubsub.toml
@@ -46,6 +46,8 @@ publisher_concurrency = 20
 [workload]
 # the number of threads that will be used to generate requests
 threads = 1
+
+[workload.ratelimit]
 # the global ratelimit
 ratelimit = 10
 

--- a/configs/momento_pubsub.toml
+++ b/configs/momento_pubsub.toml
@@ -49,7 +49,7 @@ threads = 1
 
 [workload.ratelimit]
 # the global ratelimit
-ratelimit = 10
+start = 10
 
 # An example set of topics using a low number of subscribers per topic.
 [[workload.topics]]

--- a/configs/ping.toml
+++ b/configs/ping.toml
@@ -50,7 +50,7 @@ threads = 1
 
 [workload.ratelimit]
 # set a global ratelimit for the workload
-ratelimit = 10_000
+start = 10_000
 
 # Note, even though the command does not use keys, it's still a member of a
 # keyspace.

--- a/configs/ping.toml
+++ b/configs/ping.toml
@@ -47,6 +47,8 @@ request_timeout = 1000
 [workload]
 # the number of threads that will be used to generate the workload
 threads = 1
+
+[workload.ratelimit]
 # set a global ratelimit for the workload
 ratelimit = 10_000
 

--- a/configs/ratelimit.toml
+++ b/configs/ratelimit.toml
@@ -5,9 +5,9 @@
 # specify the protocol to be used
 protocol = "memcache"
 # the interval for stats integration and reporting
-interval = 5
+interval = 15
 # the number of intervals to run the test for
-duration = 150
+duration = 300
 # optionally, we can write some detailed stats to a file during the run
 #json_output = "stats.json"
 # run the admin thread with a HTTP listener at the address provided, this allows
@@ -57,7 +57,7 @@ end = 100_000
 # end to be tested
 step = 10_000
 # time interval between steps in seconds
-interval = 15
+interval = 30
 
 [[workload.keyspace]]
 # sets the relative weight of this keyspace: defaults to 1

--- a/configs/ratelimit.toml
+++ b/configs/ratelimit.toml
@@ -49,11 +49,15 @@ request_timeout = 1000
 threads = 1
 
 [workload.ratelimit]
-# set a global ratelimit for the workload
-ratelimit = 10_000
-ratelimit_end = 100_000
-step_size = 10_000
-step_interval = 15
+# starting range of ratelimit for a dynamically changing ratelimit
+start = 10_000
+# end range for a dynamic ratelimit
+end = 100_000
+# step size for the ratelimit, i.e., number of rates between the start and
+# end to be tested
+step = 10_000
+# time interval between steps in seconds
+interval = 15
 
 [[workload.keyspace]]
 # sets the relative weight of this keyspace: defaults to 1

--- a/configs/ratelimit.toml
+++ b/configs/ratelimit.toml
@@ -5,9 +5,9 @@
 # specify the protocol to be used
 protocol = "memcache"
 # the interval for stats integration and reporting
-interval = 60
+interval = 5
 # the number of intervals to run the test for
-duration = 300
+duration = 150
 # optionally, we can write some detailed stats to a file during the run
 #json_output = "stats.json"
 # run the admin thread with a HTTP listener at the address provided, this allows
@@ -51,6 +51,9 @@ threads = 1
 [workload.ratelimit]
 # set a global ratelimit for the workload
 ratelimit = 10_000
+ratelimit_end = 100_000
+step_size = 10_000
+step_interval = 15
 
 [[workload.keyspace]]
 # sets the relative weight of this keyspace: defaults to 1

--- a/configs/redis.toml
+++ b/configs/redis.toml
@@ -49,6 +49,8 @@ request_timeout = 1000
 [workload]
 # the number of threads that will be used to generate the workload
 threads = 1
+
+[workload.ratelimit]
 # set a global ratelimit for the workload
 ratelimit = 10_000
 

--- a/configs/redis.toml
+++ b/configs/redis.toml
@@ -52,7 +52,7 @@ threads = 1
 
 [workload.ratelimit]
 # set a global ratelimit for the workload
-ratelimit = 10_000
+start = 10_000
 
 # An example keyspace showcasing the use of the `key-value` family of commands.
 #

--- a/configs/segcache.toml
+++ b/configs/segcache.toml
@@ -50,7 +50,7 @@ threads = 1
 
 [workload.ratelimit]
 # set a global ratelimit for the workload
-ratelimit = 10_000
+start = 10_000
 
 [[workload.keyspace]]
 # sets the relative weight of this keyspace: defaults to 1

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -94,7 +94,7 @@ mod filters {
     }
 }
 
-mod handlers {
+pub mod handlers {
     use super::*;
     use core::convert::Infallible;
     use std::time::UNIX_EPOCH;

--- a/src/workload/mod.rs
+++ b/src/workload/mod.rs
@@ -1,6 +1,5 @@
 use super::*;
 use config::{Command, ValueKind, Verb};
-use core::num::NonZeroU64;
 use rand::distributions::{Alphanumeric, Uniform};
 use rand::{Rng, RngCore, SeedableRng};
 use rand_distr::Distribution as RandomDistribution;
@@ -727,7 +726,6 @@ pub async fn reconnect(work_sender: Sender<ClientWorkItem>, config: Config) -> R
 
 #[derive(Clone)]
 pub struct Ratelimit {
-    start: u64,
     end: u64,
     step: u64,
     interval: Duration,
@@ -745,14 +743,12 @@ impl Ratelimit {
 
         // Unwrapping values is safe since the structure has already been
         // validated for dynamic ratelimit parameters
-        let start: u64 = ratelimit_config.start().unwrap().into();
         let end = ratelimit_config.end().unwrap();
-        let step = ratelimit_config.end().unwrap();
+        let step = ratelimit_config.step().unwrap();
         let interval = ratelimit_config.interval().unwrap();
-        let current = start;
+        let current: u64 = ratelimit_config.start().unwrap().into();
 
         Some(Ratelimit {
-            start,
             end,
             step,
             interval,


### PR DESCRIPTION
The configuration currently allows rpc-perf to be setup with a single static
ratelimit for the entire run and exposes an endpoint through which this can
be controlled externally. This adds a basic workload definition for dynamic
ratelimiting in the configuration, as well as a background thread that modifies
the ratelimit using the endpoint so that rpc-perf can run with a dynamic
ratelimit without relying on an external controller.