### PR TITLE
feat: add looping, mirroring, and randomization to ratelimit controller

### DIFF
--- a/configs/ratelimit.toml
+++ b/configs/ratelimit.toml
@@ -58,6 +58,17 @@ end = 100_000
 step = 10_000
 # time interval between steps in seconds
 interval = 30
+# specify how the workload is ramped: options are linear or shuffled
+# linear: the ratelimit is increased stepwise between the start and end range
+# shuffled: the space between start and end is explored in random order, but
+# each individual ratelimit is the same as one from the linear ramp, thereby
+# exploring all the same ratelimit points, just in a different order.
+ramp = "shuffled"
+# specify how the ratelimit is changed after the ramp is complete. options are:
+# stable: ratelimit is maintained at the final point in the ramp
+# loop: loop around and re-run the ramp from start to finish
+# mirror: run the ramp in the opposite direction and continue looping
+on_ramp_completion = "mirror"
 
 [[workload.keyspace]]
 # sets the relative weight of this keyspace: defaults to 1

--- a/configs/ratelimit.toml
+++ b/configs/ratelimit.toml
@@ -59,15 +59,15 @@ step = 10_000
 # time interval between steps in seconds
 interval = 30
 # specify how the workload is ramped: options are linear or shuffled
-# linear: the ratelimit is increased stepwise between the start and end range
-# shuffled: the space between start and end is explored in random order, but
-# each individual ratelimit is the same as one from the linear ramp, thereby
-# exploring all the same ratelimit points, just in a different order.
+#  - linear: the ratelimit is increased stepwise between the start and end range
+#  - shuffled: the space between start and end is explored in random order, but
+#    each individual ratelimit is the same as one from the linear ramp, thereby
+#    exploring all the same ratelimit points, just in a different order.
 ramp = "shuffled"
 # specify how the ratelimit is changed after the ramp is complete. options are:
-# stable: ratelimit is maintained at the final point in the ramp
-# loop: loop around and re-run the ramp from start to finish
-# mirror: run the ramp in the opposite direction and continue looping
+#  - stable: ratelimit is maintained at the final point in the ramp
+#  - loop: loop around and re-run the ramp from start to finish
+#  - mirror: run the ramp in the opposite direction and continue looping
 on_ramp_completion = "mirror"
 
 [[workload.keyspace]]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -19,7 +19,10 @@ pub use protocol::Protocol;
 pub use pubsub::Pubsub;
 pub use target::Target;
 pub use tls::Tls;
-pub use workload::{Command, Distribution, Keyspace, Topics, ValueKind, Verb, Workload};
+pub use workload::{
+    Command, Distribution, Keyspace, RampCompletionAction, RampType, Topics, ValueKind, Verb,
+    Workload,
+};
 
 pub const PAGESIZE: usize = 4096;
 pub const DEFAULT_BUFFER_SIZE: usize = 4 * PAGESIZE;

--- a/src/config/workload.rs
+++ b/src/config/workload.rs
@@ -467,6 +467,37 @@ impl Verb {
     }
 }
 
+fn ramp_linear() -> RampType {
+    RampType::Linear
+}
+
+fn ramp_completion() -> RampCompletionAction {
+    RampCompletionAction::Stable
+}
+
+// A linear ramp means that the ratelimit is increased between the start
+// and end value by the step function in a sequence. A shuffled ramp means
+// that the same stepwise ratelimits are explored in random order; however,
+// only ratelimits at the specified steps are applied.
+#[derive(Clone, Copy, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum RampType {
+    Linear,
+    Shuffled,
+}
+
+// Once the ramp is completed, the workload can remain at the final stable
+// state, it can loop around and repeat the entire workload in the same
+// sequence, or can repeat the same workload in reverse order (for example,
+// to perform a corresponding ramp-down to the initial ramp-up).
+#[derive(Clone, Copy, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum RampCompletionAction {
+    Stable,
+    Loop,
+    Mirror,
+}
+
 #[derive(Clone, Deserialize)]
 pub struct Ratelimit {
     #[serde(default)]
@@ -480,6 +511,12 @@ pub struct Ratelimit {
 
     #[serde(default)]
     interval: Option<u64>,
+
+    #[serde(default = "ramp_linear")]
+    ramp: RampType,
+
+    #[serde(default = "ramp_completion")]
+    on_ramp_completion: RampCompletionAction,
 }
 
 impl Ratelimit {
@@ -497,6 +534,14 @@ impl Ratelimit {
 
     pub fn interval(&self) -> Option<Duration> {
         self.interval.map(Duration::from_secs)
+    }
+
+    pub fn ramp_type(&self) -> RampType {
+        self.ramp
+    }
+
+    pub fn ramp_completion_action(&self) -> RampCompletionAction {
+        self.on_ramp_completion
     }
 
     pub fn is_dynamic(&self) -> bool {

--- a/src/config/workload.rs
+++ b/src/config/workload.rs
@@ -467,21 +467,14 @@ impl Verb {
     }
 }
 
-fn ramp_linear() -> RampType {
-    RampType::Linear
-}
-
-fn ramp_completion() -> RampCompletionAction {
-    RampCompletionAction::Stable
-}
-
 // A linear ramp means that the ratelimit is increased between the start
 // and end value by the step function in a sequence. A shuffled ramp means
 // that the same stepwise ratelimits are explored in random order; however,
 // only ratelimits at the specified steps are applied.
-#[derive(Clone, Copy, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Default, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum RampType {
+    #[default]
     Linear,
     Shuffled,
 }
@@ -490,9 +483,10 @@ pub enum RampType {
 // state, it can loop around and repeat the entire workload in the same
 // sequence, or can repeat the same workload in reverse order (for example,
 // to perform a corresponding ramp-down to the initial ramp-up).
-#[derive(Clone, Copy, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Default, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum RampCompletionAction {
+    #[default]
     Stable,
     Loop,
     Mirror,
@@ -512,10 +506,10 @@ pub struct Ratelimit {
     #[serde(default)]
     interval: Option<u64>,
 
-    #[serde(default = "ramp_linear")]
+    #[serde(default)]
     ramp: RampType,
 
-    #[serde(default = "ramp_completion")]
+    #[serde(default)]
     on_ramp_completion: RampCompletionAction,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,13 +181,13 @@ fn main() {
         if let Some(mut ratelimit_controller) = Ratelimit::new(&config) {
             control_runtime.spawn(async move {
                 while RUNNING.load(Ordering::Relaxed) {
-                    // delay until next step function
-                    sleep(ratelimit_controller.interval()).await;
                     let _ = admin::handlers::update_ratelimit(
                         ratelimit_controller.next_ratelimit(),
                         workload_ratelimit.clone(),
                     )
                     .await;
+                    // delay until next step function
+                    sleep(ratelimit_controller.interval()).await;
                 }
             });
         }


### PR DESCRIPTION
Allow the internal ratelimit controller to explore desired ratelimits
in random order as well as mirroring the ramp-up or looping around
and running the test again after a ramp-up cycle.