### PR TITLE
metrics: export ratelimit as a gauge

### DIFF
--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -227,6 +227,7 @@ pub mod handlers {
     ) -> Result<impl warp::Reply, Infallible> {
         if let Some(r) = ratelimit {
             let amount = (rate as f64 / 1_000_000.0).ceil() as u64;
+            RATELIMIT_CURR.set(rate as i64);
 
             // even though we might not have nanosecond level clock resolution,
             // by using a nanosecond level duration, we achieve more accurate

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,8 +151,7 @@ fn main() {
     // launch json log output
     {
         let config = config.clone();
-        let ratelimiter = workload_ratelimit.clone();
-        control_runtime.spawn_blocking(move || output::json(config, ratelimiter.as_deref()));
+        control_runtime.spawn_blocking(move || output::json(config));
     }
 
     // begin cli output

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -383,6 +383,8 @@ histogram!(PUBSUB_LATENCY, "pubsub_latency");
 
 histogram!(PUBSUB_PUBLISH_LATENCY, "pubsub_publish_latency");
 
+gauge!(RATELIMIT_CURR, "ratelimit/current");
+
 gauge!(CONNECT_CURR, "client/connections/current");
 counter!(CONNECT_OK, "client/connect/ok");
 counter!(CONNECT_TIMEOUT, "client/connect/timeout");

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,5 +1,4 @@
 use crate::*;
-use ratelimit::Ratelimiter;
 use rpcperf_dataspec::*;
 use std::io::{BufWriter, Write};
 
@@ -208,7 +207,7 @@ fn pubsub_stats(snapshot: &mut MetricsSnapshot) {
     output!("{latencies}");
 }
 
-pub fn json(config: Config, ratelimit: Option<&Ratelimiter>) {
+pub fn json(config: Config) {
     if config.general().json_output().is_none() {
         return;
     }
@@ -277,7 +276,7 @@ pub fn json(config: Config, ratelimit: Option<&Ratelimiter>) {
             let json = JsonSnapshot {
                 window: window_id,
                 elapsed,
-                target_qps: ratelimit.as_ref().map(|ratelimit| ratelimit.rate()),
+                target_qps: Some(RATELIMIT_CURR.value() as f64),
                 client: ClientStats {
                     connections,
                     requests,


### PR DESCRIPTION
The ratelimit is currently extracted from the ratelimiter every time
during output. Export it as a metrics gauge instead.