### PR TITLE
update metriken-exposition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -1697,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "metriken-exposition"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ec4da2221dfba5b474cdfd2ccab82b74b68b9df3fd4597011e58fe611ad285"
+checksum = "51211be05b38efe9bd8a4af3c2346e8f3c32b4818582a5412bb2c1f930e03892"
 dependencies = [
  "arrow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ http-body-util = "0.1.0-rc.3"
 humantime = "2.1.0"
 hyper = { version = "1.0.0-rc.4", features = ["http1", "http2", "client"]}
 metriken = "0.5.1"
-metriken-exposition = { version = "0.3.0", features = ["json", "parquet-conversion"] }
+metriken-exposition = { version = "0.4.0", features = ["json", "parquet-conversion"] }
 mio = "0.8.8"
 momento = "0.32.1"
 pelikan-net = "0.1.0"

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -225,13 +225,18 @@ pub fn metrics(config: Config) {
     let mut next = now + Duration::from_secs(1);
     let end = now + config.general().duration();
 
+    let snapshotter = SnapshotterBuilder::new()
+        .metadata("source".to_string(), env!("CARGO_BIN_NAME").to_string())
+        .metadata("version".to_string(), env!("CARGO_PKG_VERSION").to_string())
+        .build();
+
     while end > now {
         std::thread::sleep(Duration::from_millis(1));
 
         now = std::time::Instant::now();
 
         if next <= now {
-            let snapshot = SnapshotterBuilder::new().build().snapshot();
+            let snapshot = snapshotter.snapshot();
 
             let buf = match config.general().metrics_format() {
                 MetricsFormat::Json => Snapshot::to_json(&snapshot).expect("failed to serialize"),


### PR DESCRIPTION
Updates metriken-exposition so we now export top-level and metric-level metadata
