### PR TITLE
feat: add approximate compression ratio for messages and values

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -162,7 +162,7 @@ jobs:
         shell: bash
         run: |
           memcached -t 1 -p 11211 -m 256 &
-          target/release/rpc-perf configs/memcached.toml
+          target/release/rpc-perf configs/smoketest.toml
 
   check-success:
     name: verify all tests pass

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2497,6 +2497,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "flate2",
  "foreign-types-shared",
  "futures",
  "histogram 0.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ tokio-boring = "3.1.0"
 toml = "0.8.2"
 warp = "0.3.6"
 zipf = "7.0.1"
+flate2 = "1.0.28"
 
 [profile.release]
 opt-level = 3

--- a/configs/blabber.toml
+++ b/configs/blabber.toml
@@ -54,8 +54,9 @@ start = 1
 topics = 1
 topic_len = 1
 message_len = 64
-# specify an approximate compression ratio for the message payload
-compression_ratio = 1.0
+# optionally, specify an approximate compression ratio for the message payload.
+# Defaults to 1.0 meaning the message is high-entropy and not compressible.
+# compression_ratio = 1.0
 weight = 1
 # the total number of clients that will subscribe to this set of topics
 subscriber_poolsize = 100

--- a/configs/blabber.toml
+++ b/configs/blabber.toml
@@ -54,6 +54,8 @@ start = 1
 topics = 1
 topic_len = 1
 message_len = 64
+# specify an approximate compression ratio for the message payload
+compression_ratio = 1.0
 weight = 1
 # the total number of clients that will subscribe to this set of topics
 subscriber_poolsize = 100

--- a/configs/kafka.toml
+++ b/configs/kafka.toml
@@ -84,5 +84,9 @@ topic_names = ["hello", "world"]
 partitions = 10
 # the value length, in bytes
 message_len = 512
+# approximate compression ratio for the message payload. The config value
+# represents the uncompressed size divided by the compressed size. <= 1.0 means
+# the message is all random bytes. Higher values are more compressible.
+message_compression_ratio = 1.0
 # the key length, in bytes
 key_len = 8

--- a/configs/kafka.toml
+++ b/configs/kafka.toml
@@ -84,9 +84,7 @@ topic_names = ["hello", "world"]
 partitions = 10
 # the value length, in bytes
 message_len = 512
-# approximate compression ratio for the message payload. The config value
-# represents the uncompressed size divided by the compressed size. <= 1.0 means
-# the message is all random bytes. Higher values are more compressible.
-message_compression_ratio = 1.0
+# specify an approximate compression ratio for the message payload
+compression_ration = 1.0
 # the key length, in bytes
 key_len = 8

--- a/configs/kafka.toml
+++ b/configs/kafka.toml
@@ -84,7 +84,8 @@ topic_names = ["hello", "world"]
 partitions = 10
 # the value length, in bytes
 message_len = 512
-# specify an approximate compression ratio for the message payload
-compression_ration = 1.0
+# optionally, specify an approximate compression ratio for the message payload.
+# Defaults to 1.0 meaning the message is high-entropy and not compressible.
+compression_ratio = 1.0
 # the key length, in bytes
 key_len = 8

--- a/configs/memcached.toml
+++ b/configs/memcached.toml
@@ -63,7 +63,8 @@ nkeys = 1_000_000
 vlen = 128
 # use random bytes for the values
 vkind = "bytes"
-# specify an approximate compression ratio for the value
+# optionally, specify an approximate compression ratio for the value payload.
+# Defaults to 1.0 meaning the message is high-entropy and not compressible.
 compression_ratio = 1.0
 # optionally: specify a TTL for the keys, by default there is no expiration
 # ttl = "15m"

--- a/configs/memcached.toml
+++ b/configs/memcached.toml
@@ -63,6 +63,8 @@ nkeys = 1_000_000
 vlen = 128
 # use random bytes for the values
 vkind = "bytes"
+# specify an approximate compression ratio for the value
+compression_ratio = 1.0
 # optionally: specify a TTL for the keys, by default there is no expiration
 # ttl = "15m"
 # controls what commands will be used in this keyspace

--- a/configs/momento.toml
+++ b/configs/momento.toml
@@ -73,7 +73,8 @@ klen = 32
 nkeys = 1_000_000
 # sets the value length, in bytes
 vlen = 128
-# specify an approximate compression ratio for the value payload
+# optionally, specify an approximate compression ratio for the value payload.
+# Defaults to 1.0 meaning the message is high-entropy and not compressible.
 compression_ratio = 1.0
 # use random bytes for the values
 vkind = "bytes"

--- a/configs/momento.toml
+++ b/configs/momento.toml
@@ -73,6 +73,8 @@ klen = 32
 nkeys = 1_000_000
 # sets the value length, in bytes
 vlen = 128
+# specify an approximate compression ratio for the value payload
+compression_ratio = 1.0
 # use random bytes for the values
 vkind = "bytes"
 # override the default ttl for this keyspace setting it to 15 minutes

--- a/configs/momento_pubsub.toml
+++ b/configs/momento_pubsub.toml
@@ -67,6 +67,8 @@ topics = 10
 topic_len = 64
 # sets the value length, in bytes
 message_len = 128
+# specify an approximate compression ratio for the message payload
+compression_ratio = 1.0
 
 # An example set of topics using a high number of subscribers per topic.
 [[workload.topics]]
@@ -84,3 +86,5 @@ topics = 1
 topic_len = 32
 # sets the value length, in bytes
 message_len = 128
+# specify an approximate compression ratio for the message payload
+compression_ratio = 1.0

--- a/configs/momento_pubsub.toml
+++ b/configs/momento_pubsub.toml
@@ -86,5 +86,7 @@ topics = 1
 topic_len = 32
 # sets the value length, in bytes
 message_len = 128
-# specify an approximate compression ratio for the message payload
+# optionally, specify an approximate compression ratio for the message payload.
+# Defaults to 1.0 meaning the message is high-entropy and not compressible.
 compression_ratio = 1.0
+

--- a/configs/redis.toml
+++ b/configs/redis.toml
@@ -69,6 +69,9 @@ nkeys = 1_000_000
 vlen = 128
 # use random bytes for the values
 vkind = "bytes"
+# optionally, specify an approximate compression ratio for the value payload.
+# Defaults to 1.0 meaning the message is high-entropy and not compressible.
+compression_ratio = 1.0
 # optionally: specify a TTL for the keys, by default there is no expiration
 # ttl = "15m"
 # controls what commands will be used in this keyspace

--- a/configs/segcache.toml
+++ b/configs/segcache.toml
@@ -86,10 +86,8 @@ nkeys = 1_000_000
 vlen = 128
 # use random bytes for the values
 vkind = "bytes"
-# approximate compression ratio for the value. The config value represents the
-# uncompressed size divided by the compressed size. <= 1.0 means the value is
-# all random bytes. Higher values are more compressible.
-message_compression_ratio = 1.0
+# specify an approximate compression ratio for the value payload
+compression_ratio = 1.0
 # controls what commands will be used in this keyspace
 commands = [
 	# get a value

--- a/configs/segcache.toml
+++ b/configs/segcache.toml
@@ -83,6 +83,10 @@ nkeys = 1_000_000
 vlen = 128
 # use random bytes for the values
 vkind = "bytes"
+# approximate compression ratio for the value. The config value represents the
+# uncompressed size divided by the compressed size. <= 1.0 means the value is
+# all random bytes. Higher values are more compressible.
+message_compression_ratio = 1.0
 # controls what commands will be used in this keyspace
 commands = [
 	# get a value

--- a/configs/segcache.toml
+++ b/configs/segcache.toml
@@ -86,7 +86,8 @@ nkeys = 1_000_000
 vlen = 128
 # use random bytes for the values
 vkind = "bytes"
-# specify an approximate compression ratio for the value payload
+# optionally, specify an approximate compression ratio for the value payload.
+# Defaults to 1.0 meaning the message is high-entropy and not compressible.
 compression_ratio = 1.0
 # controls what commands will be used in this keyspace
 commands = [

--- a/configs/smoketest.toml
+++ b/configs/smoketest.toml
@@ -36,7 +36,7 @@ klen = 32
 nkeys = 1_000_000
 vlen = 128
 vkind = "bytes"
-message_compression_ratio = 10.0
+compression_ratio = 10.0
 commands = [
 	{ verb = "get", weight = 80 },
 	{ verb = "set", weight = 20 },

--- a/configs/smoketest.toml
+++ b/configs/smoketest.toml
@@ -1,0 +1,44 @@
+# A configuration that can be used as a smoketest against a memcached instance.
+
+[general]
+protocol = "memcache"
+interval = 60
+duration = 300
+metrics_output = "rpcperf.parquet"
+metrics_format = "parquet"
+admin = "127.0.0.1:9090"
+
+[debug]
+log_level = "info"
+log_backup = "rpc-perf.log.old"
+log_max_size = 1073741824
+
+[target]
+endpoints = [
+	"127.0.0.1:11211",
+]
+
+[client]
+threads = 4
+poolsize = 20
+connect_timeout = 10000
+request_timeout = 1000
+
+[workload]
+threads = 1
+
+[workload.ratelimit]
+start = 10_000
+
+[[workload.keyspace]]
+weight = 1
+klen = 32
+nkeys = 1_000_000
+vlen = 128
+vkind = "bytes"
+message_compression_ratio = 10.0
+commands = [
+	{ verb = "get", weight = 80 },
+	{ verb = "set", weight = 20 },
+	{ verb = "delete", weight = 0 },
+]

--- a/configs/smoketest.toml
+++ b/configs/smoketest.toml
@@ -2,8 +2,8 @@
 
 [general]
 protocol = "memcache"
-interval = 60
-duration = 300
+interval = 1
+duration = 60
 metrics_output = "rpcperf.parquet"
 metrics_format = "parquet"
 admin = "127.0.0.1:9090"

--- a/src/config/workload.rs
+++ b/src/config/workload.rs
@@ -49,7 +49,7 @@ pub struct Topics {
     topic_names: Vec<String>,
     message_len: usize,
     #[serde(default)]
-    message_compression_ratio: Option<f64>,
+    compression_ratio: Option<f64>,
     #[serde(default = "one")]
     key_len: usize,
     weight: usize,
@@ -91,8 +91,8 @@ impl Topics {
         self.message_len
     }
 
-    pub fn message_compression_ratio(&self) -> f64 {
-        self.message_compression_ratio.unwrap_or(1.0)
+    pub fn compression_ratio(&self) -> f64 {
+        self.compression_ratio.unwrap_or(1.0)
     }
 
     pub fn subscriber_poolsize(&self) -> usize {
@@ -145,7 +145,7 @@ pub struct Keyspace {
     #[serde(default)]
     vkind: Option<ValueKind>,
     #[serde(default)]
-    value_compression_ratio: Option<f64>,
+    compression_ratio: Option<f64>,
     #[serde(default)]
     // no ttl is treated as no-expires or max ttl for the protocol
     ttl: Option<String>,
@@ -188,8 +188,8 @@ impl Keyspace {
         self.vkind.unwrap_or(ValueKind::Bytes)
     }
 
-    pub fn value_compression_ratio(&self) -> f64 {
-        self.value_compression_ratio.unwrap_or(1.0)
+    pub fn compression_ratio(&self) -> f64 {
+        self.compression_ratio.unwrap_or(1.0)
     }
 
     pub fn ttl(&self) -> Option<Duration> {

--- a/src/config/workload.rs
+++ b/src/config/workload.rs
@@ -48,6 +48,8 @@ pub struct Topics {
     #[serde(default)]
     topic_names: Vec<String>,
     message_len: usize,
+    #[serde(default)]
+    message_compression_ratio: Option<f64>,
     #[serde(default = "one")]
     key_len: usize,
     weight: usize,
@@ -87,6 +89,10 @@ impl Topics {
 
     pub fn message_len(&self) -> usize {
         self.message_len
+    }
+
+    pub fn message_compression_ratio(&self) -> f64 {
+        self.message_compression_ratio.unwrap_or(1.0)
     }
 
     pub fn subscriber_poolsize(&self) -> usize {
@@ -139,6 +145,8 @@ pub struct Keyspace {
     #[serde(default)]
     vkind: Option<ValueKind>,
     #[serde(default)]
+    value_compression_ratio: Option<f64>,
+    #[serde(default)]
     // no ttl is treated as no-expires or max ttl for the protocol
     ttl: Option<String>,
 }
@@ -178,6 +186,10 @@ impl Keyspace {
 
     pub fn vkind(&self) -> ValueKind {
         self.vkind.unwrap_or(ValueKind::Bytes)
+    }
+
+    pub fn value_compression_ratio(&self) -> f64 {
+        self.value_compression_ratio.unwrap_or(1.0)
     }
 
     pub fn ttl(&self) -> Option<Duration> {

--- a/src/workload/mod.rs
+++ b/src/workload/mod.rs
@@ -1,15 +1,16 @@
 use super::*;
 use config::{Command, RampCompletionAction, RampType, ValueKind, Verb};
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use rand::distributions::{Alphanumeric, Uniform};
 use rand::seq::SliceRandom;
-use rand::thread_rng;
-use rand::{Rng, RngCore, SeedableRng};
+use rand::{thread_rng, Rng, RngCore, SeedableRng};
 use rand_distr::Distribution as RandomDistribution;
 use rand_distr::WeightedAliasIndex;
 use rand_xoshiro::{Seed512, Xoshiro512PlusPlus};
 use ratelimit::Ratelimiter;
 use std::collections::{HashMap, HashSet};
-use std::io::Result;
+use std::io::{Result, Write};
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
@@ -162,7 +163,7 @@ impl Generator {
         // add a header
         [m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7]] =
             [0x54, 0x45, 0x53, 0x54, 0x49, 0x4E, 0x47, 0x21];
-        rng.fill(&mut m[32..topics.message_len]);
+        rng.fill(&mut m[32..(topics.message_random_bytes + 32)]);
         let mut k = vec![0_u8; topics.key_len];
         rng.fill(&mut k[0..topics.key_len]);
 
@@ -391,12 +392,54 @@ pub struct Topics {
     partition_dist: Distribution,
     key_len: usize,
     message_len: usize,
+    message_random_bytes: usize,
     subscriber_poolsize: usize,
     subscriber_concurrency: usize,
 }
 
 impl Topics {
     pub fn new(config: &Config, topics: &config::Topics) -> Self {
+        let message_random_bytes = if topics.message_compression_ratio() <= 1.0 {
+            // this indicates the message should not be compressible, to achieve
+            // this all bytes will be random
+            topics.message_len()
+        } else {
+            // we need to approximate the number of random bytes to send, we do
+            // this iteratively assuming gzip compression.
+
+            // doesn't matter what seed we use here
+            let mut rng = Xoshiro512PlusPlus::from_seed(config.general().initial_seed());
+
+            // message buffer
+            let mut m = vec![0; topics.message_len()];
+
+            let mut best = 0;
+
+            for idx in 0..m.len() {
+                // zero all bytes
+                for b in &mut m {
+                    *b = 0
+                }
+
+                // fill first N bytes with pseudorandom data
+                rng.fill_bytes(&mut m[0..idx]);
+
+                let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+                let _ = encoder.write_all(&m);
+                let compressed = encoder.finish().unwrap();
+
+                let ratio = m.len() as f64 / compressed.len() as f64;
+
+                if ratio < topics.message_compression_ratio() {
+                    break;
+                }
+
+                best = idx;
+            }
+
+            best
+        };
+
         // ntopics must be >= 1
         let ntopics = std::cmp::max(1, topics.topics());
         // partitions must be >= 1
@@ -458,6 +501,7 @@ impl Topics {
             partition_dist,
             key_len,
             message_len,
+            message_random_bytes,
             subscriber_poolsize,
             subscriber_concurrency,
         }
@@ -490,6 +534,7 @@ pub struct Keyspace {
     inner_key_dist: Distribution,
     vlen: usize,
     vkind: ValueKind,
+    value_random_bytes: usize,
     ttl: Option<Duration>,
 }
 
@@ -510,6 +555,48 @@ impl Distribution {
 
 impl Keyspace {
     pub fn new(config: &Config, keyspace: &config::Keyspace) -> Self {
+        let value_random_bytes =
+            if keyspace.value_compression_ratio() <= 1.0 || keyspace.vlen().is_none() {
+                // this indicates the message should not be compressible, to achieve
+                // this all bytes will be random
+                keyspace.vlen().unwrap_or(0)
+            } else {
+                // we need to approximate the number of random bytes to send, we do
+                // this iteratively assuming gzip compression.
+
+                // doesn't matter what seed we use here
+                let mut rng = Xoshiro512PlusPlus::from_seed(config.general().initial_seed());
+
+                // message buffer
+                let mut m = vec![0; keyspace.vlen().unwrap_or(0)];
+
+                let mut best = 0;
+
+                for idx in 0..m.len() {
+                    // zero all bytes
+                    for b in &mut m {
+                        *b = 0
+                    }
+
+                    // fill first N bytes with pseudorandom data
+                    rng.fill_bytes(&mut m[0..idx]);
+
+                    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+                    let _ = encoder.write_all(&m);
+                    let compressed = encoder.finish().unwrap();
+
+                    let ratio = m.len() as f64 / compressed.len() as f64;
+
+                    if ratio < keyspace.value_compression_ratio() {
+                        break;
+                    }
+
+                    best = idx;
+                }
+
+                best
+            };
+
         // nkeys must be >= 1
         let nkeys = std::cmp::max(1, keyspace.nkeys());
         let klen = keyspace.klen();
@@ -655,6 +742,7 @@ impl Keyspace {
             inner_key_dist,
             vlen: keyspace.vlen().unwrap_or(0),
             vkind: keyspace.vkind(),
+            value_random_bytes,
             ttl: keyspace.ttl(),
         }
     }
@@ -674,7 +762,7 @@ impl Keyspace {
             ValueKind::I64 => format!("{}", rng.gen::<i64>()).into_bytes(),
             ValueKind::Bytes => {
                 let mut buf = vec![0_u8; self.vlen];
-                rng.fill(&mut buf[0..self.vlen]);
+                rng.fill(&mut buf[0..self.value_random_bytes]);
                 buf
             }
         }

--- a/src/workload/mod.rs
+++ b/src/workload/mod.rs
@@ -399,7 +399,7 @@ pub struct Topics {
 
 impl Topics {
     pub fn new(config: &Config, topics: &config::Topics) -> Self {
-        let message_random_bytes = if topics.message_compression_ratio() <= 1.0 {
+        let message_random_bytes = if topics.compression_ratio() <= 1.0 {
             // this indicates the message should not be compressible, to achieve
             // this all bytes will be random
             topics.message_len()
@@ -430,7 +430,7 @@ impl Topics {
 
                 let ratio = m.len() as f64 / compressed.len() as f64;
 
-                if ratio < topics.message_compression_ratio() {
+                if ratio < topics.compression_ratio() {
                     break;
                 }
 
@@ -556,7 +556,7 @@ impl Distribution {
 impl Keyspace {
     pub fn new(config: &Config, keyspace: &config::Keyspace) -> Self {
         let value_random_bytes =
-            if keyspace.value_compression_ratio() <= 1.0 || keyspace.vlen().is_none() {
+            if keyspace.compression_ratio() <= 1.0 || keyspace.vlen().is_none() {
                 // this indicates the message should not be compressible, to achieve
                 // this all bytes will be random
                 keyspace.vlen().unwrap_or(0)
@@ -587,7 +587,7 @@ impl Keyspace {
 
                     let ratio = m.len() as f64 / compressed.len() as f64;
 
-                    if ratio < keyspace.value_compression_ratio() {
+                    if ratio < keyspace.compression_ratio() {
                         break;
                     }
 


### PR DESCRIPTION
Adds approximate compression ratio targeting for messages and values.

This is done by limiting the number of random bytes in the payload to the first N bytes and iteratively estimating the compression ratio using gzip.
