### PR TITLE
switch to openssl

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -129,16 +129,16 @@ jobs:
       - name: build
         shell: bash
         run: |
-          cargo build --workspace --all-features --all-targets --locked ${{ env.FLAGS }}
+          cargo build --workspace --all-targets --locked ${{ env.FLAGS }}
       - name: test
         shell: bash
         run: |
-          cargo test --workspace --all-features --tests --bins --locked ${{ env.FLAGS }}
+          cargo test --workspace --tests --bins --locked ${{ env.FLAGS }}
       - name: doctests
         if: ${{ matrix.profile == 'debug' }}
         shell: bash
         run: |
-          cargo test --workspace --all-features --locked -- --test-threads 16
+          cargo test --workspace --locked -- --test-threads 16
 
       - name: generate bin artifact
         if: ${{ matrix.profile == 'release' && matrix.os == 'ubuntu-latest' }}
@@ -170,7 +170,7 @@ jobs:
       - name: build
         shell: bash
         run: |
-          cargo build --workspace --all-features --all-targets --locked --release
+          cargo build --workspace --all-targets --locked --release
       - name: test
         shell: bash
         run: |

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -25,6 +25,19 @@ jobs:
       - name: cargo check
         run: |
           cargo check --all-targets
+
+  check-powerset:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: swlynch99/cargo-sweep-action@v1
+      - uses: taiki-e/install-action@cargo-hack
+
+      - name: check powerset
+        run: |
+          cargo hack --feature-powerset check --locked
   
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,6 +2114,8 @@ dependencies = [
  "libc",
  "metriken 0.3.5",
  "mio",
+ "openssl",
+ "openssl-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ checksum = "7ae1aba472e42d3cf45ac6d0a6c8fc3ddf743871209e1b40229aed9fbdf48ece"
 dependencies = [
  "bitflags 2.5.0",
  "boring-sys",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
  "once_cell",
 ]
@@ -684,12 +684,11 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#f2f936b5017e11856a493255b0fbb3a845e65623"
 dependencies = [
  "boring",
  "clocksource",
  "metriken 0.3.5",
- "pelikan-net 0.1.0 (git+https://github.com/pelikan-io/pelikan)",
+ "pelikan-net",
  "ringlog",
  "serde",
 ]
@@ -706,7 +705,6 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#f2f936b5017e11856a493255b0fbb3a845e65623"
 dependencies = [
  "common",
  "log",
@@ -908,12 +906,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -926,6 +933,12 @@ dependencies = [
  "quote",
  "syn 2.0.58",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1590,7 +1603,6 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 [[package]]
 name = "logger"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#f2f936b5017e11856a493255b0fbb3a845e65623"
 dependencies = [
  "common",
  "config",
@@ -1957,10 +1969,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-src"
+version = "300.2.3+3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-float"
@@ -2040,26 +2100,12 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pelikan-net"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b120fd5d897107cb459176e5db0dd409056b11848accd0f4dcfc690b8bdac9b3"
+version = "0.2.0"
 dependencies = [
  "boring",
  "boring-sys",
- "foreign-types-shared",
- "libc",
- "metriken 0.3.5",
- "mio",
-]
-
-[[package]]
-name = "pelikan-net"
-version = "0.1.0"
-source = "git+https://github.com/pelikan-io/pelikan#f2f936b5017e11856a493255b0fbb3a845e65623"
-dependencies = [
- "boring",
- "boring-sys",
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+ "foreign-types-shared 0.3.1",
  "libc",
  "metriken 0.3.5",
  "mio",
@@ -2226,7 +2272,6 @@ dependencies = [
 [[package]]
 name = "protocol-common"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#f2f936b5017e11856a493255b0fbb3a845e65623"
 dependencies = [
  "bytes",
  "common",
@@ -2238,7 +2283,6 @@ dependencies = [
 [[package]]
 name = "protocol-memcache"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#f2f936b5017e11856a493255b0fbb3a845e65623"
 dependencies = [
  "clocksource",
  "common",
@@ -2251,7 +2295,6 @@ dependencies = [
 [[package]]
 name = "protocol-ping"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#f2f936b5017e11856a493255b0fbb3a845e65623"
 dependencies = [
  "common",
  "config",
@@ -2497,7 +2540,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
  "futures",
  "histogram 0.10.0",
  "http-body-util",
@@ -2508,8 +2551,10 @@ dependencies = [
  "mio",
  "momento",
  "once_cell",
+ "openssl",
+ "openssl-sys",
  "paste",
- "pelikan-net 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pelikan-net",
  "protocol-memcache",
  "protocol-ping",
  "rand",
@@ -2526,6 +2571,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-boring",
+ "tokio-openssl",
  "toml",
  "warp",
  "zipf",
@@ -2741,14 +2787,13 @@ dependencies = [
 [[package]]
 name = "session"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#f2f936b5017e11856a493255b0fbb3a845e65623"
 dependencies = [
  "bytes",
  "clocksource",
  "common",
  "log",
  "metriken 0.3.5",
- "pelikan-net 0.1.0 (git+https://github.com/pelikan-io/pelikan)",
+ "pelikan-net",
  "protocol-common",
 ]
 
@@ -2875,7 +2920,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage-types"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#f2f936b5017e11856a493255b0fbb3a845e65623"
 
 [[package]]
 name = "strsim"
@@ -3058,6 +3102,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.58",
+]
+
+[[package]]
+name = "tokio-openssl"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ffab79df67727f6acf57f1ff743091873c24c579b1e2ce4d8f53e47ded4d63d"
+dependencies = [
+ "futures-util",
+ "openssl",
+ "openssl-sys",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,9 +684,8 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
+source = "git+https://github.com/pelikan-io/pelikan#9f50b746d7c50a25773c685cb47e9eed3551944c"
 dependencies = [
- "boring",
  "clocksource",
  "metriken 0.3.5",
  "pelikan-net 0.2.0 (git+https://github.com/pelikan-io/pelikan)",
@@ -706,7 +705,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
+source = "git+https://github.com/pelikan-io/pelikan#9f50b746d7c50a25773c685cb47e9eed3551944c"
 dependencies = [
  "common",
  "log",
@@ -1605,7 +1604,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 [[package]]
 name = "logger"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
+source = "git+https://github.com/pelikan-io/pelikan#9f50b746d7c50a25773c685cb47e9eed3551944c"
 dependencies = [
  "common",
  "config",
@@ -2104,8 +2103,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 [[package]]
 name = "pelikan-net"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c373eceaca2782371375d31bb2f7cd5ef1b493516253efd32dfea907c21f2b7"
+source = "git+https://github.com/brayniac/pelikan#da4a1410f6c1465d60c511c9f1fee568561dda1a"
 dependencies = [
  "boring",
  "boring-sys",
@@ -2121,10 +2119,8 @@ dependencies = [
 [[package]]
 name = "pelikan-net"
 version = "0.2.0"
-source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
+source = "git+https://github.com/pelikan-io/pelikan#9f50b746d7c50a25773c685cb47e9eed3551944c"
 dependencies = [
- "boring",
- "boring-sys",
  "foreign-types-shared 0.1.1",
  "foreign-types-shared 0.3.1",
  "libc",
@@ -2293,7 +2289,7 @@ dependencies = [
 [[package]]
 name = "protocol-common"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
+source = "git+https://github.com/pelikan-io/pelikan#9f50b746d7c50a25773c685cb47e9eed3551944c"
 dependencies = [
  "bytes",
  "common",
@@ -2305,7 +2301,7 @@ dependencies = [
 [[package]]
 name = "protocol-memcache"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
+source = "git+https://github.com/pelikan-io/pelikan#9f50b746d7c50a25773c685cb47e9eed3551944c"
 dependencies = [
  "clocksource",
  "common",
@@ -2318,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "protocol-ping"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
+source = "git+https://github.com/pelikan-io/pelikan#9f50b746d7c50a25773c685cb47e9eed3551944c"
 dependencies = [
  "common",
  "config",
@@ -2578,7 +2574,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "paste",
- "pelikan-net 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pelikan-net 0.2.0 (git+https://github.com/brayniac/pelikan)",
  "protocol-memcache",
  "protocol-ping",
  "rand",
@@ -2811,7 +2807,7 @@ dependencies = [
 [[package]]
 name = "session"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
+source = "git+https://github.com/pelikan-io/pelikan#9f50b746d7c50a25773c685cb47e9eed3551944c"
 dependencies = [
  "bytes",
  "clocksource",
@@ -2945,7 +2941,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage-types"
 version = "0.3.1"
-source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
+source = "git+https://github.com/pelikan-io/pelikan#9f50b746d7c50a25773c685cb47e9eed3551944c"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,11 +684,12 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.3.1"
+source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
 dependencies = [
  "boring",
  "clocksource",
  "metriken 0.3.5",
- "pelikan-net",
+ "pelikan-net 0.2.0 (git+https://github.com/pelikan-io/pelikan)",
  "ringlog",
  "serde",
 ]
@@ -705,6 +706,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.3.1"
+source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
 dependencies = [
  "common",
  "log",
@@ -1603,6 +1605,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 [[package]]
 name = "logger"
 version = "0.3.1"
+source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
 dependencies = [
  "common",
  "config",
@@ -2101,6 +2104,22 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 [[package]]
 name = "pelikan-net"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c373eceaca2782371375d31bb2f7cd5ef1b493516253efd32dfea907c21f2b7"
+dependencies = [
+ "boring",
+ "boring-sys",
+ "foreign-types-shared 0.1.1",
+ "foreign-types-shared 0.3.1",
+ "libc",
+ "metriken 0.3.5",
+ "mio",
+]
+
+[[package]]
+name = "pelikan-net"
+version = "0.2.0"
+source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
 dependencies = [
  "boring",
  "boring-sys",
@@ -2272,6 +2291,7 @@ dependencies = [
 [[package]]
 name = "protocol-common"
 version = "0.3.1"
+source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
 dependencies = [
  "bytes",
  "common",
@@ -2283,6 +2303,7 @@ dependencies = [
 [[package]]
 name = "protocol-memcache"
 version = "0.3.1"
+source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
 dependencies = [
  "clocksource",
  "common",
@@ -2295,6 +2316,7 @@ dependencies = [
 [[package]]
 name = "protocol-ping"
 version = "0.3.1"
+source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
 dependencies = [
  "common",
  "config",
@@ -2554,7 +2576,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "paste",
- "pelikan-net",
+ "pelikan-net 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protocol-memcache",
  "protocol-ping",
  "rand",
@@ -2787,13 +2809,14 @@ dependencies = [
 [[package]]
 name = "session"
 version = "0.3.1"
+source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
 dependencies = [
  "bytes",
  "clocksource",
  "common",
  "log",
  "metriken 0.3.5",
- "pelikan-net",
+ "pelikan-net 0.2.0 (git+https://github.com/pelikan-io/pelikan)",
  "protocol-common",
 ]
 
@@ -2920,6 +2943,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage-types"
 version = "0.3.1"
+source = "git+https://github.com/pelikan-io/pelikan#0c05f32292edeaa729b46f65baccdf0a04094e4c"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,7 +2103,8 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 [[package]]
 name = "pelikan-net"
 version = "0.2.0"
-source = "git+https://github.com/brayniac/pelikan#da4a1410f6c1465d60c511c9f1fee568561dda1a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c373eceaca2782371375d31bb2f7cd5ef1b493516253efd32dfea907c21f2b7"
 dependencies = [
  "boring",
  "boring-sys",
@@ -2574,7 +2575,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "paste",
- "pelikan-net 0.2.0 (git+https://github.com/brayniac/pelikan)",
+ "pelikan-net 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protocol-memcache",
  "protocol-ping",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ license = "MIT OR Apache-2.0"
 ahash = "0.8.3"
 async-channel = "1.9.0"
 backtrace = "0.3.69"
-boring = "3.1.0"
-boring-sys = "3.1.0"
+boring = { version = "3.1.0", optional = true }
+boring-sys = { version = "3.1.0", optional = true }
 bytes = "1.5.0"
 chrono = "0.4.31"
 clap = "4.4.6"
@@ -27,11 +27,13 @@ metriken = "0.6.0"
 metriken-exposition = { version = "0.5.0", features = ["json", "parquet-conversion"] }
 mio = "0.8.8"
 momento = "0.32.1"
-pelikan-net = "0.1.0"
+pelikan-net = { path = "../pelikan/src/net", version = "0.2.0" }
 once_cell = "1.18.0"
+openssl = { version = "0.10.64", optional = true }
+openssl-sys = { version = "0.9.102", optional = true }
 paste = "1.0.14"
-protocol-memcache = { git = "https://github.com/pelikan-io/pelikan" }
-protocol-ping = { git = "https://github.com/pelikan-io/pelikan" }
+protocol-memcache = { path = "../pelikan/src/protocol/memcache" }
+protocol-ping = { path = "../pelikan/src/protocol/ping" }
 rand = "0.8.5"
 rand_distr = "0.4.3"
 rand_xoshiro = "0.6.0"
@@ -40,15 +42,21 @@ redis = { version = "0.23.3", features = ["tokio-comp"] }
 rdkafka = { version = "0.34.0", features = ["cmake-build"] }
 ringlog = "0.5.0"
 serde = { version = "1.0.185", features = ["derive"] }
-session = { git = "https://github.com/pelikan-io/pelikan" }
+session = { path = "../pelikan/src/session" }
 sha2 = "0.10.8"
 slab = "0.4.9"
 tempfile = "3.10.1"
 tokio = { version = "1.33.0", features = ["full"] }
-tokio-boring = "3.1.0"
+tokio-boring = { version = "3.1.0", optional = true }
+tokio-openssl = { version = "0.6.4", optional = true }
 toml = "0.8.2"
 warp = "0.3.6"
 zipf = "7.0.1"
+
+[features]
+default = ["openssl"]
+boringssl = ["dep:boring", "boring-sys", "tokio-boring"]
+openssl = ["dep:openssl", "openssl-sys", "openssl/vendored", "tokio-openssl"]
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,13 @@ metriken = "0.6.0"
 metriken-exposition = { version = "0.5.0", features = ["json", "parquet-conversion"] }
 mio = "0.8.8"
 momento = "0.32.1"
-pelikan-net = { path = "../pelikan/src/net", version = "0.2.0" }
+pelikan-net = "0.2.0"
 once_cell = "1.18.0"
 openssl = { version = "0.10.64", optional = true }
 openssl-sys = { version = "0.9.102", optional = true }
 paste = "1.0.14"
-protocol-memcache = { path = "../pelikan/src/protocol/memcache" }
-protocol-ping = { path = "../pelikan/src/protocol/ping" }
+protocol-memcache = { git = "https://github.com/pelikan-io/pelikan" }
+protocol-ping = { git = "https://github.com/pelikan-io/pelikan" }
 rand = "0.8.5"
 rand_distr = "0.4.3"
 rand_xoshiro = "0.6.0"
@@ -42,7 +42,7 @@ redis = { version = "0.23.3", features = ["tokio-comp"] }
 rdkafka = { version = "0.34.0", features = ["cmake-build"] }
 ringlog = "0.5.0"
 serde = { version = "1.0.185", features = ["derive"] }
-session = { path = "../pelikan/src/session" }
+session = { git = "https://github.com/pelikan-io/pelikan" }
 sha2 = "0.10.8"
 slab = "0.4.9"
 tempfile = "3.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ metriken = "0.6.0"
 metriken-exposition = { version = "0.5.0", features = ["json", "parquet-conversion"] }
 mio = "0.8.8"
 momento = "0.32.1"
-pelikan-net = { git = "https://github.com/brayniac/pelikan", default-features = false }
+pelikan-net = { version = "0.2.0", default-features = false }
 once_cell = "1.18.0"
 openssl = { version = "0.10.64", optional = true }
 openssl-sys = { version = "0.9.102", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ metriken = "0.6.0"
 metriken-exposition = { version = "0.5.0", features = ["json", "parquet-conversion"] }
 mio = "0.8.8"
 momento = "0.32.1"
-pelikan-net = "0.2.0"
+pelikan-net = { version = "0.2.0", default-features = false }
 once_cell = "1.18.0"
 openssl = { version = "0.10.64", optional = true }
 openssl-sys = { version = "0.9.102", optional = true }
@@ -55,8 +55,8 @@ zipf = "7.0.1"
 
 [features]
 default = ["openssl"]
-boringssl = ["dep:boring", "boring-sys", "tokio-boring"]
-openssl = ["dep:openssl", "openssl-sys", "openssl/vendored", "tokio-openssl"]
+boringssl = ["dep:boring", "boring-sys", "tokio-boring", "pelikan-net/boringssl"]
+openssl = ["dep:openssl", "openssl-sys", "openssl/vendored", "tokio-openssl", "pelikan-net/openssl"]
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ metriken = "0.6.0"
 metriken-exposition = { version = "0.5.0", features = ["json", "parquet-conversion"] }
 mio = "0.8.8"
 momento = "0.32.1"
-pelikan-net = { version = "0.2.0", default-features = false }
+pelikan-net = { git = "https://github.com/brayniac/pelikan", default-features = false }
 once_cell = "1.18.0"
 openssl = { version = "0.10.64", optional = true }
 openssl-sys = { version = "0.9.102", optional = true }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,9 +1,37 @@
+use crate::error;
 use crate::Config;
-use boring::ssl::{SslFiletype, SslMethod};
-use boring::x509::X509;
-use std::io::{Error, ErrorKind, Result};
-use tokio::io::ReadBuf;
-use tokio::io::{AsyncRead, AsyncWrite};
+
+use std::io::Result;
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+pub enum SslProvider {
+    #[cfg(feature = "boringssl")]
+    Boringssl,
+    #[cfg(feature = "openssl")]
+    Openssl,
+    Unknown,
+}
+
+// clippy doesn't realize that the default changes depending on enabled features
+// so we suppress this warning
+#[allow(clippy::derivable_impls)]
+#[allow(unreachable_code)]
+impl Default for SslProvider {
+    fn default() -> Self {
+        #[cfg(feature = "boringssl")]
+        {
+            return SslProvider::Boringssl;
+        }
+        
+        #[cfg(feature = "openssl")]
+        {
+            return SslProvider::Openssl;
+        }
+
+        SslProvider::Unknown
+    }
+}
 
 pub struct Connector {
     inner: ConnectorImpl,
@@ -11,6 +39,34 @@ pub struct Connector {
 
 impl Connector {
     pub fn new(config: &Config) -> Result<Self> {
+        if config.tls().is_none() {
+            Self::plaintext()
+        } else {
+            match SslProvider::default() {
+                #[cfg(feature = "boringssl")]
+                SslProvider::Boringssl => {
+                    Self::boringssl(config)
+                }
+                #[cfg(feature = "openssl")]
+                SslProvider::Openssl => {
+                    Self::openssl(config)
+                }
+                SslProvider::Unknown => {
+                    error!("no TLS/SSL provider could be found. Check that rpc-perf was built with either boringssl or openssl support");
+                    std::process::exit(1);
+                }
+            }
+        }
+    }
+
+    fn plaintext() -> Result<Self> {
+        Ok(Connector {
+            inner: ConnectorImpl::Tcp,
+        })
+    }
+
+    #[cfg(feature = "boringssl")]
+    fn boringssl(config: &Config) -> Result<Self> {
         if config.tls().is_none() {
             return Ok(Connector {
                 inner: ConnectorImpl::Tcp,
@@ -23,7 +79,7 @@ impl Connector {
         let certificate = tls_config.certificate();
         let certificate_chain = tls_config.certificate_chain();
 
-        let mut ssl_connector = boring::ssl::SslConnector::builder(SslMethod::tls_client())?;
+        let mut ssl_connector = boring::ssl::SslConnector::builder(boring::ssl::SslMethod::tls_client())?;
 
         if let Some(ca_file) = tls_config.ca_file() {
             ssl_connector.set_ca_file(ca_file)?;
@@ -31,16 +87,16 @@ impl Connector {
 
         // mTLS configuration
         if private_key.is_some() && (certificate.is_some() || certificate_chain.is_some()) {
-            ssl_connector.set_private_key_file(private_key.unwrap(), SslFiletype::PEM)?;
+            ssl_connector.set_private_key_file(private_key.unwrap(), boring::ssl::SslFiletype::PEM)?;
 
             match (certificate, certificate_chain) {
                 (Some(cert), Some(chain)) => {
                     // assume cert is just a leaf and that we need to append the
                     // certs in the chain file after loading the leaf cert
 
-                    ssl_connector.set_certificate_file(cert, SslFiletype::PEM)?;
+                    ssl_connector.set_certificate_file(cert, boring::ssl::SslFiletype::PEM)?;
                     let pem = std::fs::read(chain)?;
-                    let chain = X509::stack_from_pem(&pem)?;
+                    let chain = boring::x509::X509::stack_from_pem(&pem)?;
                     for cert in chain {
                         ssl_connector.add_extra_chain_cert(cert)?;
                     }
@@ -60,13 +116,73 @@ impl Connector {
         let ssl_connector = ssl_connector.build();
 
         Ok(Connector {
-            inner: ConnectorImpl::TlsTcp(TlsTcpConnector {
+            inner: ConnectorImpl::BoringsslTlsTcp(BoringsslTlsTcp {
                 inner: ssl_connector,
                 verify_hostname: tls_config.verify_hostname(),
                 use_sni: tls_config.use_sni(),
             }),
         })
     }
+
+    #[cfg(feature = "openssl")]
+    fn openssl(config: &Config) -> Result<Self> {
+        if config.tls().is_none() {
+            return Ok(Connector {
+                inner: ConnectorImpl::Tcp,
+            });
+        }
+
+        let tls_config = config.tls().unwrap();
+
+        let private_key = tls_config.private_key();
+        let certificate = tls_config.certificate();
+        let certificate_chain = tls_config.certificate_chain();
+
+        let mut ssl_connector = openssl::ssl::SslConnector::builder(openssl::ssl::SslMethod::tls_client())?;
+
+        if let Some(ca_file) = tls_config.ca_file() {
+            ssl_connector.set_ca_file(ca_file)?;
+        }
+
+        // mTLS configuration
+        if private_key.is_some() && (certificate.is_some() || certificate_chain.is_some()) {
+            ssl_connector.set_private_key_file(private_key.unwrap(), openssl::ssl::SslFiletype::PEM)?;
+
+            match (certificate, certificate_chain) {
+                (Some(cert), Some(chain)) => {
+                    // assume cert is just a leaf and that we need to append the
+                    // certs in the chain file after loading the leaf cert
+
+                    ssl_connector.set_certificate_file(cert, openssl::ssl::SslFiletype::PEM)?;
+                    let pem = std::fs::read(chain)?;
+                    let chain = openssl::x509::X509::stack_from_pem(&pem)?;
+                    for cert in chain {
+                        ssl_connector.add_extra_chain_cert(cert)?;
+                    }
+                }
+                (Some(cert), None) => {
+                    // treat cert file like it's a chain for convenience
+                    ssl_connector.set_certificate_chain_file(cert)?;
+                }
+                (None, Some(chain)) => {
+                    // load all certs from chain
+                    ssl_connector.set_certificate_chain_file(chain)?;
+                }
+                (None, None) => unreachable!(),
+            }
+        }
+
+        let ssl_connector = ssl_connector.build();
+
+        Ok(Connector {
+            inner: ConnectorImpl::OpensslTlsTcp(OpensslTlsTcp {
+                inner: ssl_connector,
+                verify_hostname: tls_config.verify_hostname(),
+                use_sni: tls_config.use_sni(),
+            }),
+        })
+    }
+
 
     pub async fn connect(&self, addr: &str) -> Result<Stream> {
         match &self.inner {
@@ -80,7 +196,8 @@ impl Connector {
                     inner: StreamImpl::Tcp(s),
                 })
             }
-            ConnectorImpl::TlsTcp(connector) => {
+            #[cfg(feature = "boringssl")]
+            ConnectorImpl::BoringsslTlsTcp(connector) => {
                 let stream = tokio::net::TcpStream::connect(addr).await?;
                 let domain = addr.split(':').next().unwrap().to_owned();
 
@@ -92,11 +209,34 @@ impl Connector {
 
                 match tokio_boring::connect(config, &domain, stream).await {
                     Ok(stream) => Ok(Stream {
-                        inner: StreamImpl::TlsTcp(stream),
+                        inner: StreamImpl::BoringsslTlsTcp(stream),
                     }),
                     Err(e) => match e.as_io_error() {
-                        Some(e) => Err(Error::new(e.kind(), e.to_string())),
-                        None => Err(Error::new(ErrorKind::Other, e.to_string())),
+                        Some(e) => Err(std::io::Error::new(e.kind(), e.to_string())),
+                        None => Err(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())),
+                    },
+                }
+            }
+            #[cfg(feature = "openssl")]
+            ConnectorImpl::OpensslTlsTcp(connector) => {
+                let stream = tokio::net::TcpStream::connect(addr).await?;
+                let domain = addr.split(':').next().unwrap().to_owned();
+
+                let config = connector
+                    .inner
+                    .configure()?
+                    .verify_hostname(connector.verify_hostname)
+                    .use_server_name_indication(connector.use_sni);
+
+                let mut ssl = tokio_openssl::SslStream::new(config.into_ssl(&domain)?, stream)?;
+
+                match tokio_openssl::SslStream::connect(std::pin::Pin::new(&mut ssl)).await {
+                    Ok(_) => Ok(Stream {
+                        inner: StreamImpl::OpensslTlsTcp(ssl),
+                    }),
+                    Err(e) => match e.io_error() {
+                        Some(e) => Err(std::io::Error::new(e.kind(), e.to_string())),
+                        None => Err(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())),
                     },
                 }
             }
@@ -106,11 +246,22 @@ impl Connector {
 
 enum ConnectorImpl {
     Tcp,
-    TlsTcp(TlsTcpConnector),
+    #[cfg(feature = "boringssl")]
+    BoringsslTlsTcp(BoringsslTlsTcp),
+    #[cfg(feature = "openssl")]
+    OpensslTlsTcp(OpensslTlsTcp),
 }
 
-pub struct TlsTcpConnector {
+#[cfg(feature = "boringssl")]
+pub struct BoringsslTlsTcp {
     inner: boring::ssl::SslConnector,
+    verify_hostname: bool,
+    use_sni: bool,
+}
+
+#[cfg(feature = "openssl")]
+pub struct OpensslTlsTcp {
+    inner: openssl::ssl::SslConnector,
     verify_hostname: bool,
     use_sni: bool,
 }
@@ -121,7 +272,10 @@ pub struct Stream {
 
 enum StreamImpl {
     Tcp(tokio::net::TcpStream),
-    TlsTcp(tokio_boring::SslStream<tokio::net::TcpStream>),
+    #[cfg(feature = "boringssl")]
+    BoringsslTlsTcp(tokio_boring::SslStream<tokio::net::TcpStream>),
+    #[cfg(feature = "openssl")]
+    OpensslTlsTcp(tokio_openssl::SslStream<tokio::net::TcpStream>),
 }
 
 impl AsyncRead for Stream {
@@ -132,7 +286,10 @@ impl AsyncRead for Stream {
     ) -> std::task::Poll<std::result::Result<(), std::io::Error>> {
         match &mut self.inner {
             StreamImpl::Tcp(s) => std::pin::Pin::new(s).poll_read(cx, buf),
-            StreamImpl::TlsTcp(s) => std::pin::Pin::new(s).poll_read(cx, buf),
+            #[cfg(feature = "boringssl")]
+            StreamImpl::BoringsslTlsTcp(s) => std::pin::Pin::new(s).poll_read(cx, buf),
+            #[cfg(feature = "openssl")]
+            StreamImpl::OpensslTlsTcp(s) => std::pin::Pin::new(s).poll_read(cx, buf),
         }
     }
 }
@@ -145,7 +302,10 @@ impl AsyncWrite for Stream {
     ) -> std::task::Poll<std::result::Result<usize, std::io::Error>> {
         match &mut self.inner {
             StreamImpl::Tcp(s) => std::pin::Pin::new(s).poll_write(cx, buf),
-            StreamImpl::TlsTcp(s) => std::pin::Pin::new(s).poll_write(cx, buf),
+            #[cfg(feature = "boringssl")]
+            StreamImpl::BoringsslTlsTcp(s) => std::pin::Pin::new(s).poll_write(cx, buf),
+            #[cfg(feature = "openssl")]
+            StreamImpl::OpensslTlsTcp(s) => std::pin::Pin::new(s).poll_write(cx, buf),
         }
     }
     fn poll_flush(
@@ -154,7 +314,10 @@ impl AsyncWrite for Stream {
     ) -> std::task::Poll<std::result::Result<(), std::io::Error>> {
         match &mut self.inner {
             StreamImpl::Tcp(s) => std::pin::Pin::new(s).poll_flush(cx),
-            StreamImpl::TlsTcp(s) => std::pin::Pin::new(s).poll_flush(cx),
+            #[cfg(feature = "boringssl")]
+            StreamImpl::BoringsslTlsTcp(s) => std::pin::Pin::new(s).poll_flush(cx),
+            #[cfg(feature = "openssl")]
+            StreamImpl::OpensslTlsTcp(s) => std::pin::Pin::new(s).poll_flush(cx),
         }
     }
     fn poll_shutdown(
@@ -163,7 +326,10 @@ impl AsyncWrite for Stream {
     ) -> std::task::Poll<std::result::Result<(), std::io::Error>> {
         match &mut self.inner {
             StreamImpl::Tcp(s) => std::pin::Pin::new(s).poll_shutdown(cx),
-            StreamImpl::TlsTcp(s) => std::pin::Pin::new(s).poll_shutdown(cx),
+            #[cfg(feature = "boringssl")]
+            StreamImpl::BoringsslTlsTcp(s) => std::pin::Pin::new(s).poll_shutdown(cx),
+            #[cfg(feature = "openssl")]
+            StreamImpl::OpensslTlsTcp(s) => std::pin::Pin::new(s).poll_shutdown(cx),
         }
     }
 }
@@ -179,7 +345,13 @@ impl hyper::rt::Read for Stream {
                 let mut buf = ReadBuf::uninit(unsafe { rbc.as_mut() });
                 std::pin::Pin::new(s).poll_read(cx, &mut buf)
             }
-            StreamImpl::TlsTcp(s) => {
+            #[cfg(feature = "boringssl")]
+            StreamImpl::BoringsslTlsTcp(s) => {
+                let mut buf = ReadBuf::uninit(unsafe { rbc.as_mut() });
+                std::pin::Pin::new(s).poll_read(cx, &mut buf)
+            }
+            #[cfg(feature = "openssl")]
+            StreamImpl::OpensslTlsTcp(s) => {
                 let mut buf = ReadBuf::uninit(unsafe { rbc.as_mut() });
                 std::pin::Pin::new(s).poll_read(cx, &mut buf)
             }
@@ -195,7 +367,10 @@ impl hyper::rt::Write for Stream {
     ) -> std::task::Poll<std::result::Result<usize, std::io::Error>> {
         match &mut self.inner {
             StreamImpl::Tcp(s) => std::pin::Pin::new(s).poll_write(cx, buf),
-            StreamImpl::TlsTcp(s) => std::pin::Pin::new(s).poll_write(cx, buf),
+            #[cfg(feature = "boringssl")]
+            StreamImpl::BoringsslTlsTcp(s) => std::pin::Pin::new(s).poll_write(cx, buf),
+            #[cfg(feature = "openssl")]
+            StreamImpl::OpensslTlsTcp(s) => std::pin::Pin::new(s).poll_write(cx, buf),
         }
     }
 
@@ -205,7 +380,10 @@ impl hyper::rt::Write for Stream {
     ) -> std::task::Poll<std::result::Result<(), std::io::Error>> {
         match &mut self.inner {
             StreamImpl::Tcp(s) => std::pin::Pin::new(s).poll_flush(cx),
-            StreamImpl::TlsTcp(s) => std::pin::Pin::new(s).poll_flush(cx),
+            #[cfg(feature = "boringssl")]
+            StreamImpl::BoringsslTlsTcp(s) => std::pin::Pin::new(s).poll_flush(cx),
+            #[cfg(feature = "openssl")]
+            StreamImpl::OpensslTlsTcp(s) => std::pin::Pin::new(s).poll_flush(cx),
         }
     }
 
@@ -215,7 +393,10 @@ impl hyper::rt::Write for Stream {
     ) -> std::task::Poll<std::result::Result<(), std::io::Error>> {
         match &mut self.inner {
             StreamImpl::Tcp(s) => std::pin::Pin::new(s).poll_shutdown(cx),
-            StreamImpl::TlsTcp(s) => std::pin::Pin::new(s).poll_shutdown(cx),
+            #[cfg(feature = "boringssl")]
+            StreamImpl::BoringsslTlsTcp(s) => std::pin::Pin::new(s).poll_shutdown(cx),
+            #[cfg(feature = "openssl")]
+            StreamImpl::OpensslTlsTcp(s) => std::pin::Pin::new(s).poll_shutdown(cx),
         }
     }
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -23,7 +23,7 @@ impl Default for SslProvider {
         {
             return SslProvider::Boringssl;
         }
-        
+
         #[cfg(feature = "openssl")]
         {
             return SslProvider::Openssl;
@@ -44,13 +44,9 @@ impl Connector {
         } else {
             match SslProvider::default() {
                 #[cfg(feature = "boringssl")]
-                SslProvider::Boringssl => {
-                    Self::boringssl(config)
-                }
+                SslProvider::Boringssl => Self::boringssl(config),
                 #[cfg(feature = "openssl")]
-                SslProvider::Openssl => {
-                    Self::openssl(config)
-                }
+                SslProvider::Openssl => Self::openssl(config),
                 SslProvider::Unknown => {
                     error!("no TLS/SSL provider could be found. Check that rpc-perf was built with either boringssl or openssl support");
                     std::process::exit(1);
@@ -79,7 +75,8 @@ impl Connector {
         let certificate = tls_config.certificate();
         let certificate_chain = tls_config.certificate_chain();
 
-        let mut ssl_connector = boring::ssl::SslConnector::builder(boring::ssl::SslMethod::tls_client())?;
+        let mut ssl_connector =
+            boring::ssl::SslConnector::builder(boring::ssl::SslMethod::tls_client())?;
 
         if let Some(ca_file) = tls_config.ca_file() {
             ssl_connector.set_ca_file(ca_file)?;
@@ -87,7 +84,8 @@ impl Connector {
 
         // mTLS configuration
         if private_key.is_some() && (certificate.is_some() || certificate_chain.is_some()) {
-            ssl_connector.set_private_key_file(private_key.unwrap(), boring::ssl::SslFiletype::PEM)?;
+            ssl_connector
+                .set_private_key_file(private_key.unwrap(), boring::ssl::SslFiletype::PEM)?;
 
             match (certificate, certificate_chain) {
                 (Some(cert), Some(chain)) => {
@@ -138,7 +136,8 @@ impl Connector {
         let certificate = tls_config.certificate();
         let certificate_chain = tls_config.certificate_chain();
 
-        let mut ssl_connector = openssl::ssl::SslConnector::builder(openssl::ssl::SslMethod::tls_client())?;
+        let mut ssl_connector =
+            openssl::ssl::SslConnector::builder(openssl::ssl::SslMethod::tls_client())?;
 
         if let Some(ca_file) = tls_config.ca_file() {
             ssl_connector.set_ca_file(ca_file)?;
@@ -146,7 +145,8 @@ impl Connector {
 
         // mTLS configuration
         if private_key.is_some() && (certificate.is_some() || certificate_chain.is_some()) {
-            ssl_connector.set_private_key_file(private_key.unwrap(), openssl::ssl::SslFiletype::PEM)?;
+            ssl_connector
+                .set_private_key_file(private_key.unwrap(), openssl::ssl::SslFiletype::PEM)?;
 
             match (certificate, certificate_chain) {
                 (Some(cert), Some(chain)) => {
@@ -183,7 +183,6 @@ impl Connector {
         })
     }
 
-
     pub async fn connect(&self, addr: &str) -> Result<Stream> {
         match &self.inner {
             ConnectorImpl::Tcp => {
@@ -213,7 +212,10 @@ impl Connector {
                     }),
                     Err(e) => match e.as_io_error() {
                         Some(e) => Err(std::io::Error::new(e.kind(), e.to_string())),
-                        None => Err(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())),
+                        None => Err(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            e.to_string(),
+                        )),
                     },
                 }
             }
@@ -236,7 +238,10 @@ impl Connector {
                     }),
                     Err(e) => match e.io_error() {
                         Some(e) => Err(std::io::Error::new(e.kind(), e.to_string())),
-                        None => Err(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())),
+                        None => Err(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            e.to_string(),
+                        )),
                     },
                 }
             }


### PR DESCRIPTION
We experienced linking issues when adding TLS support for the kafka client. This was because we depend on boringssl which has symbol collisions with openssl during linking. 

This change gives us the ability to build with either openssl or boringssl as the TLS/SSL provider. The default is switched to openssl so we can integrate the kafka TLS support.