### PR TITLE
add /quitquitquit

### DIFF
--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -253,8 +253,14 @@ pub async fn metrics(config: Config) {
         .metadata("version".to_string(), env!("CARGO_PKG_VERSION").to_string())
         .build();
 
-    while Instant::now() + config.general().interval() <= stop {
-        interval.tick().await;
+    while RUNNING.load(Ordering::Relaxed) && Instant::now() + config.general().interval() <= stop {
+        // use a timeout here so we always check RUNNING at least once a second
+        if timeout(Duration::from_secs(1), interval.tick())
+            .await
+            .is_err()
+        {
+            continue;
+        }
 
         let snapshot = snapshotter.snapshot();
 


### PR DESCRIPTION
Adds a /quitquitquit endpoint so that the test can be terminated early.
