### PR TITLE
config: move metrics configuration to separate section

### DIFF
--- a/configs/segcache.toml
+++ b/configs/segcache.toml
@@ -15,7 +15,7 @@ admin = "127.0.0.1:9090"
 # The default is to intialize from the OS entropy pool.
 #initial_seed = "0"
 
-[metrics]
+#[metrics]
 # output file for detailed stats during the run
 #output = "stats.json"
 # format of the output file (possible values are json, msgpack, parquet)

--- a/configs/segcache.toml
+++ b/configs/segcache.toml
@@ -8,20 +8,27 @@ protocol = "memcache"
 interval = 60
 # the number of intervals to run the test for
 duration = 300
-# optionally, we can write some detailed stats to a file during the run
-#metrics_output = "stats.json"
-# optionally, specify the format for the output stats file (default is json)
-# possible values are (json, msgpack, parquet).
-#metrics_format = "parquet"
-# optionally, specify the sampling interval for metrics. Input is a string
-# with the unit attached; for example "100ms" or "1s". Default to 100ms.
-#metrics_interval = "1s"
 # run the admin thread with a HTTP listener at the address provided, this allows
 # stats exposition via HTTP
 admin = "127.0.0.1:9090"
 # optionally, set an initial seed for the PRNGs used to generate the workload.
 # The default is to intialize from the OS entropy pool.
 #initial_seed = "0"
+
+[metrics]
+# output file for detailed stats during the run
+#output = "stats.json"
+# format of the output file (possible values are json, msgpack, parquet)
+#format = "json"
+# optionally specify batch size for parquet row groups
+# only valid for parquet output
+#batch_size = 100_000
+# optionally specify histogram type (can be standard (default) or sparse)
+# only valid for parquet output
+#histogram = "sparse"
+# optionally, specify the sampling interval for metrics. Input is a string
+# with the unit attached; for example "100ms" or "1s". Default to 100ms.
+#interval = "1s"
 
 [debug]
 # choose from: error, warn, info, debug, trace

--- a/src/config/general.rs
+++ b/src/config/general.rs
@@ -1,17 +1,8 @@
 use super::*;
 use rand::Rng;
 use rand_xoshiro::Seed512;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use sha2::{Digest, Sha512};
-
-#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum MetricsFormat {
-    #[default]
-    Json,
-    MsgPack,
-    Parquet,
-}
 
 pub fn metrics_interval() -> String {
     "100ms".into()
@@ -64,11 +55,8 @@ impl General {
         self.metrics_format
     }
 
-    pub fn metrics_interval(&self) -> Duration {
-        self.metrics_interval
-            .parse::<humantime::Duration>()
-            .unwrap()
-            .into()
+    pub fn metrics_interval(&self) -> &String {
+        &self.metrics_interval
     }
 
     pub fn admin(&self) -> String {
@@ -85,20 +73,6 @@ impl General {
             let mut seed = [0_u8; 64];
             rng.fill(&mut seed);
             Seed512(seed)
-        }
-    }
-
-    pub fn validate(&self) {
-        let interval = self.metrics_interval.parse::<humantime::Duration>();
-        if let Err(e) = interval {
-            eprintln!("metrics_interval is not valid: {e}");
-            std::process::exit(1);
-        }
-
-        let interval = interval.unwrap().as_millis();
-        if interval < Duration::from_millis(10).as_millis() {
-            eprintln!("metrics_interval should be larger than 10ms");
-            std::process::exit(1);
         }
     }
 }

--- a/src/config/metrics.rs
+++ b/src/config/metrics.rs
@@ -1,0 +1,132 @@
+use super::*;
+use metriken_exposition::ParquetHistogramType;
+use serde::{Deserialize, Serialize};
+
+use crate::General;
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Format {
+    #[default]
+    Json,
+    MsgPack,
+    Parquet,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HistogramType {
+    #[default]
+    Standard,
+    Sparse,
+}
+
+impl From<HistogramType> for ParquetHistogramType {
+    fn from(h: HistogramType) -> Self {
+        match h {
+            HistogramType::Standard => ParquetHistogramType::Standard,
+            HistogramType::Sparse => ParquetHistogramType::Sparse,
+        }
+    }
+}
+
+pub fn interval() -> String {
+    "100ms".into()
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Metrics {
+    /// File for output metrics
+    output: String,
+    /// Format for output metrics
+    format: Format,
+    /// Batch size for parquet files
+    batch_size: Option<usize>,
+    /// Type of histogram stored: sparse or dense
+    #[serde(default)]
+    histogram: HistogramType,
+    /// The reporting interval. Specify time along with unit; default to 100ms.
+    #[serde(default = "interval")]
+    interval: String,
+}
+
+impl Metrics {
+    pub fn from_general(general: &General) -> Option<Self> {
+        Some(Metrics {
+            output: general.metrics_output()?,
+            format: general.metrics_format(),
+            batch_size: None,
+            histogram: HistogramType::default(),
+            interval: general.metrics_interval().clone(),
+        })
+    }
+
+    pub fn validate(&self, general: &General) {
+        if let Some(x) = self.batch_size {
+            if self.format != Format::Parquet {
+                eprintln!("batch size is only valid for parquet files");
+                std::process::exit(1);
+            }
+
+            // Allow values between 100 and 10M
+            if !(100..=10_000_000).contains(&x) {
+                eprintln!("batch size should be in range [0, 10,000,000]");
+                std::process::exit(1);
+            }
+        }
+
+        let interval = self.interval.parse::<humantime::Duration>();
+        if let Err(e) = interval {
+            eprintln!("metrics_interval is not valid: {e}");
+            std::process::exit(1);
+        }
+
+        let interval = interval.unwrap().as_millis();
+        if interval < Duration::from_millis(10).as_millis() {
+            eprintln!("metrics_interval should be larger than 10ms");
+            std::process::exit(1);
+        }
+
+        // Compare values between general and metrics section and warn if they
+        // differ. Use the values from the metrics section if both are present.
+        if let Some(x) = general.metrics_output() {
+            if x != self.output {
+                eprintln!("Output file in metrics ({}) and general ({}) section differ; using metrics value", self.output, x);
+            }
+
+            if self.format != general.metrics_format() {
+                eprintln!(
+                    "Output format in metrics and general section differ; using metrics value"
+                );
+            }
+
+            if self.interval != *general.metrics_interval() {
+                eprintln!(
+                    "Interval in metrics ({}) and general ({}) section differ; using metrics value",
+                    self.interval,
+                    general.metrics_interval()
+                );
+            }
+        }
+    }
+
+    pub fn output(&self) -> &String {
+        &self.output
+    }
+
+    pub fn format(&self) -> Format {
+        self.format
+    }
+
+    pub fn batch_size(&self) -> Option<usize> {
+        self.batch_size
+    }
+
+    pub fn histogram(&self) -> HistogramType {
+        self.histogram
+    }
+
+    pub fn interval(&self) -> Duration {
+        self.interval.parse::<humantime::Duration>().unwrap().into()
+    }
+}

--- a/src/config/metrics.rs
+++ b/src/config/metrics.rs
@@ -91,21 +91,25 @@ impl Metrics {
         // differ. Use the values from the metrics section if both are present.
         if let Some(x) = general.metrics_output() {
             if x != self.output {
-                eprintln!("Output file in metrics ({}) and general ({}) section differ; using metrics value", self.output, x);
+                eprintln!(
+                    "Output file in metrics ({}) and general ({}) section differ, exiting...",
+                    self.output, x
+                );
+                std::process::exit(1);
             }
 
             if self.format != general.metrics_format() {
-                eprintln!(
-                    "Output format in metrics and general section differ; using metrics value"
-                );
+                eprintln!("Output format in metrics and general section differ, exiting...");
+                std::process::exit(1);
             }
 
             if self.interval != *general.metrics_interval() {
                 eprintln!(
-                    "Interval in metrics ({}) and general ({}) section differ; using metrics value",
+                    "Interval in metrics ({}) and general ({}) section differ, exiting...",
                     self.interval,
                     general.metrics_interval()
                 );
+                std::process::exit(1);
             }
         }
     }


### PR DESCRIPTION
Move configuration of metrics output to a separate section
in the configuration file. At the moment, allow metrics
configuration to be specified in the old, i.e, via the
general section, or the new, i.e., via the metrics section.
If configuration parameters in both sections are in conflict,
use the ones from the metrics section.