### PR TITLE
momento: support store workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,12 +461,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -1463,20 +1457,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebtoken"
-version = "8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
-dependencies = [
- "base64 0.21.7",
- "pem",
- "ring 0.16.20",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,16 +1736,15 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcee54e75b9c1f7c9124ebd55628daf646fc97d90adfbe1d3c5628dd807268c7"
+checksum = "1204a297ff85c045ad5e98dee7015a170215b966d87f1a75ce7acce9f829ba1c"
 dependencies = [
  "base64 0.21.7",
  "derive_more",
  "futures",
  "h2 0.3.26",
  "hyper 0.14.28",
- "jsonwebtoken",
  "log",
  "momento-protos",
  "rand",
@@ -1778,9 +1757,9 @@ dependencies = [
 
 [[package]]
 name = "momento-protos"
-version = "0.110.2"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146ca03e9125b9635bab14efec8b352930a2a06fe9de5c16138cb89bc71dcad7"
+checksum = "af2da0a52df61c39b7de6c68f0b6149d6373b178529a3b21c2204480bb02632f"
 dependencies = [
  "prost",
  "tonic",
@@ -1806,7 +1785,7 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "spin 0.9.8",
+ "spin",
  "version_check",
 ]
 
@@ -2103,15 +2082,6 @@ dependencies = [
  "libc",
  "metriken",
  "mio",
-]
-
-[[package]]
-name = "pem"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
-dependencies = [
- "base64 0.13.1",
 ]
 
 [[package]]
@@ -2464,21 +2434,6 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -2487,8 +2442,8 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
+ "spin",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -2618,7 +2573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring",
  "rustls-webpki",
  "sct",
 ]
@@ -2650,8 +2605,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2693,8 +2648,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2842,18 +2797,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simple_asn1"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror",
- "time",
-]
-
-[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2899,12 +2842,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -3389,12 +3326,6 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -3531,16 +3462,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
-
-[[package]]
-name = "web-sys"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ hyper = { version = "1.0.0-rc.4", features = ["http1", "http2", "client"]}
 metriken = "0.7.0"
 metriken-exposition = { version = "0.8.0", features = ["json", "parquet-conversion"] }
 mio = "0.8.8"
-momento = "0.40.0"
+momento = "0.42.0"
 pelikan-net = { version = "0.3.0", default-features = false }
 once_cell = "1.18.0"
 openssl = { version = "0.10.64", optional = true }

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -1,5 +1,4 @@
 use crate::workload::ClientRequest;
-use crate::workload::ClientWorkItem as WorkItem;
 use crate::*;
 
 use ::momento::{MomentoError, MomentoErrorCode};
@@ -7,6 +6,7 @@ use async_channel::Receiver;
 use tokio::io::*;
 use tokio::runtime::Runtime;
 use tokio::time::{timeout, Duration};
+use workload::ClientWorkItemKind;
 
 use std::io::{Error, ErrorKind, Result};
 use std::time::Instant;
@@ -18,7 +18,10 @@ mod momento;
 mod ping;
 mod redis;
 
-pub fn launch_clients(config: &Config, work_receiver: Receiver<WorkItem>) -> Option<Runtime> {
+pub fn launch_clients(
+    config: &Config,
+    work_receiver: Receiver<ClientWorkItemKind<ClientRequest>>,
+) -> Option<Runtime> {
     debug!("Launching clients...");
 
     config.client()?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,6 +9,7 @@ mod general;
 mod metrics;
 mod protocol;
 mod pubsub;
+mod storage;
 mod target;
 mod tls;
 mod workload;
@@ -19,11 +20,12 @@ pub use general::General;
 pub use metrics::{Format as MetricsFormat, Metrics};
 pub use protocol::Protocol;
 pub use pubsub::Pubsub;
+pub use storage::Storage;
 pub use target::Target;
 pub use tls::Tls;
 pub use workload::{
-    Command, Distribution, Keyspace, RampCompletionAction, RampType, Topics, ValueKind, Verb,
-    Workload,
+    Command, Distribution, Keyspace, RampCompletionAction, RampType, Store, StoreCommand,
+    StoreVerb, Topics, ValueKind, Verb, Workload,
 };
 
 pub const PAGESIZE: usize = 4096;
@@ -43,6 +45,7 @@ pub struct Config {
     tls: Option<Tls>,
     workload: Workload,
     metrics: Option<Metrics>,
+    storage: Option<Storage>,
 }
 
 impl Config {
@@ -109,5 +112,9 @@ impl Config {
 
     pub fn metrics(&self) -> Option<&Metrics> {
         self.metrics.as_ref()
+    }
+
+    pub fn storage(&self) -> Option<&Storage> {
+        self.storage.as_ref()
     }
 }

--- a/src/config/storage.rs
+++ b/src/config/storage.rs
@@ -1,0 +1,37 @@
+use super::*;
+
+#[derive(Clone, Deserialize)]
+pub struct Storage {
+    /// The number of connections this process will have to each endpoint.
+    poolsize: usize,
+    /// The number of concurrent sessions per connection.
+    #[serde(default)]
+    concurrency: usize,
+    /// Request timeout
+    request_timeout: u64,
+    // number of threads for client tasks
+    threads: usize,
+    store_name: Option<String>,
+}
+
+impl Storage {
+    pub fn threads(&self) -> usize {
+        self.threads
+    }
+
+    pub fn request_timeout(&self) -> Duration {
+        Duration::from_millis(self.request_timeout)
+    }
+
+    pub fn poolsize(&self) -> usize {
+        std::cmp::max(1, self.poolsize)
+    }
+
+    pub fn concurrency(&self) -> usize {
+        std::cmp::max(1, self.concurrency)
+    }
+
+    pub fn store_name(&self) -> Option<&str> {
+        self.store_name.as_deref()
+    }
+}

--- a/src/config/workload.rs
+++ b/src/config/workload.rs
@@ -673,9 +673,9 @@ pub enum StoreVerb {
     /// Read the value for one a key.
     /// * Momento: `get`
     Get,
-    /// Set the value for a key.
-    /// * Momento: `set`
-    Set,
+    /// Put the value for a key.
+    /// * Momento: `put`
+    Put,
     /// Remove a key.
     /// * Momento: `delete`
     #[serde(alias = "del")]

--- a/src/config/workload.rs
+++ b/src/config/workload.rs
@@ -9,6 +9,8 @@ pub struct Workload {
     #[serde(default)]
     keyspace: Vec<Keyspace>,
     #[serde(default)]
+    stores: Vec<Store>,
+    #[serde(default)]
     topics: Vec<Topics>,
     threads: usize,
     ratelimit: Ratelimit,
@@ -26,6 +28,10 @@ impl Workload {
         &self.keyspace
     }
 
+    pub fn stores(&self) -> &[Store] {
+        &self.stores
+    }
+
     pub fn topics(&self) -> &[Topics] {
         &self.topics
     }
@@ -36,6 +42,59 @@ impl Workload {
 
     pub fn ratelimit(&self) -> &Ratelimit {
         &self.ratelimit
+    }
+}
+
+#[derive(Clone, Deserialize)]
+pub struct Store {
+    #[serde(default)]
+    nkeys: usize,
+    #[serde(default)]
+    klen: usize,
+    #[serde(default)]
+    key_distribution: Distribution,
+    #[serde(default = "one")]
+    weight: usize,
+    commands: Vec<StoreCommand>,
+    #[serde(default)]
+    vlen: Option<usize>,
+    #[serde(default)]
+    vkind: Option<ValueKind>,
+    #[serde(default)]
+    compression_ratio: Option<f64>,
+}
+
+impl Store {
+    pub fn nkeys(&self) -> usize {
+        self.nkeys
+    }
+
+    pub fn klen(&self) -> usize {
+        self.klen
+    }
+
+    pub fn key_distribution(&self) -> Distribution {
+        self.key_distribution
+    }
+
+    pub fn weight(&self) -> usize {
+        self.weight
+    }
+
+    pub fn commands(&self) -> &[StoreCommand] {
+        &self.commands
+    }
+
+    pub fn vlen(&self) -> Option<usize> {
+        self.vlen
+    }
+
+    pub fn vkind(&self) -> ValueKind {
+        self.vkind.unwrap_or(ValueKind::Bytes)
+    }
+
+    pub fn compression_ratio(&self) -> f64 {
+        self.compression_ratio.unwrap_or(1.0)
     }
 }
 
@@ -581,4 +640,44 @@ impl Ratelimit {
             std::process::exit(2);
         }
     }
+}
+
+#[derive(Clone, Copy, Deserialize)]
+pub struct StoreCommand {
+    verb: StoreVerb,
+    #[serde(default = "one")]
+    weight: usize,
+}
+
+impl StoreCommand {
+    pub fn verb(&self) -> StoreVerb {
+        self.verb
+    }
+
+    pub fn weight(&self) -> usize {
+        self.weight
+    }
+}
+
+#[derive(Clone, Deserialize, Copy, Debug, Ord, Eq, PartialOrd, PartialEq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum StoreVerb {
+    /// Sends a `PING` to the server and expects a `PONG`
+    /// * Ping: `PING`
+    /// * RESP: `PING`
+    Ping,
+
+    /*
+     * KEY-VALUE
+     */
+    /// Read the value for one a key.
+    /// * Momento: `get`
+    Get,
+    /// Set the value for a key.
+    /// * Momento: `set`
+    Set,
+    /// Remove a key.
+    /// * Momento: `delete`
+    #[serde(alias = "del")]
+    Delete,
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -405,16 +405,19 @@ counter!(
     "client/request/dropped",
     "number of requests dropped due to a full work queue"
 );
+
 counter!(
     REQUEST_OK,
     "client/request/ok",
     "requests that were successfully generated and sent"
 );
+
 counter!(
     REQUEST_RECONNECT,
     "client/connect/reconnect",
     "requests to reconnect"
 );
+
 counter!(
     REQUEST_UNSUPPORTED,
     "client/request/unsupported",
@@ -455,26 +458,31 @@ counter!(
     "client/response/exception",
     "responses which encountered some exception while processing"
 );
+
 counter!(
     RESPONSE_RATELIMITED,
     "client/response/ratelimited",
     "backend indicated that we were ratelimited"
 );
+
 counter!(
     RESPONSE_BACKEND_TIMEOUT,
     "client/response/backend_timeout",
     "responses indicating the backend timedout"
 );
+
 counter!(
     RESPONSE_OK,
     "client/response/ok",
     "responses which were successful"
 );
+
 counter!(
     RESPONSE_TIMEOUT,
     "client/response/timeout",
     "responses not received due to timeout"
 );
+
 counter!(
     RESPONSE_INVALID,
     "client/response/invalid",
@@ -625,3 +633,99 @@ counter!(PUBSUB_RECEIVE_CLOSED, "subscriber/receive/closed");
 counter!(PUBSUB_RECEIVE_CORRUPT, "subscriber/receive/corrupt");
 counter!(PUBSUB_RECEIVE_INVALID, "subscriber/receive/invalid");
 counter!(PUBSUB_RECEIVE_OK, "subscriber/receive/ok");
+
+/*
+ * STORE CLIENT
+ *
+ * This is distinct from regular client metrics, as one may want to test
+ * regular cache clients side-by-side with a distinctly configured store client.
+ */
+histogram!(
+    STORE_RESPONSE_LATENCY,
+    "store_response_latency",
+    "distribution of response latencies in nanoseconds."
+);
+
+counter!(STORE_CONNECT, "store_client/connect/total");
+counter!(STORE_CONNECT_OK, "store_client/connect/ok");
+counter!(STORE_CONNECT_EX, "store_client/connect/exception");
+counter!(STORE_CONNECT_TIMEOUT, "store_client/connect/timeout");
+gauge!(STORE_CONNECT_CURR, "store_client/connections/current");
+counter!(
+    STORE_REQUEST,
+    "store_client/request/total",
+    "total requests dequeued"
+);
+counter!(
+    STORE_REQUEST_DROPPED,
+    "store_client/request/dropped",
+    "number of requests dropped due to a full work queue"
+);
+counter!(
+    STORE_REQUEST_OK,
+    "store_client/request/ok",
+    "requests that were successfully generated and sent"
+);
+
+counter!(
+    STORE_REQUEST_RECONNECT,
+    "store_client/connect/reconnect",
+    "requests to reconnect"
+);
+
+counter!(
+    STORE_REQUEST_UNSUPPORTED,
+    "store_client/request/unsupported",
+    "skipped requests due to protocol incompatibility"
+);
+
+counter!(
+    STORE_RESPONSE_EX,
+    "store_client/response/exception",
+    "responses which encountered some exception while processing"
+);
+
+counter!(
+    STORE_RESPONSE_RATELIMITED,
+    "store_client/response/ratelimited",
+    "backend indicated that we were ratelimited"
+);
+
+counter!(
+    STORE_RESPONSE_BACKEND_TIMEOUT,
+    "store_client/response/backend_timeout",
+    "responses indicating the backend timedout"
+);
+
+counter!(
+    STORE_RESPONSE_OK,
+    "store_client/response/ok",
+    "responses which were successful"
+);
+
+counter!(
+    STORE_RESPONSE_TIMEOUT,
+    "store_client/response/timeout",
+    "responses not received due to timeout"
+);
+
+counter!(
+    STORE_RESPONSE_INVALID,
+    "store_client/response/invalid",
+    "responses that were invalid for the protocol"
+);
+
+counter!(STORE_RESPONSE_FOUND, "store_client/response/found");
+counter!(STORE_RESPONSE_NOT_FOUND, "store_client/response/not_found");
+
+/*
+ * STORE
+ */
+request!(STORE_GET, "store_get");
+counter!(STORE_GET_KEY_FOUND, "store_get/found");
+counter!(STORE_GET_KEY_NOT_FOUND, "store_get/not_found");
+
+request!(STORE_PUT, "store_put");
+counter!(STORE_PUT_STORED, "store_put/stored");
+
+request!(STORE_DELETE, "store_delete");

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -30,6 +30,7 @@ pub async fn log(config: Config) {
 
     let client = !config.workload().keyspaces().is_empty();
     let pubsub = !config.workload().topics().is_empty();
+    let store = !config.workload().stores().is_empty();
 
     // get an aligned start time
     let start = tokio::time::Instant::now() - Duration::from_nanos(Utc::now().nanosecond() as u64)
@@ -62,6 +63,11 @@ pub async fn log(config: Config) {
         // output the pubsub stats
         if pubsub {
             pubsub_stats(&mut snapshot);
+        }
+
+        // output the store stats
+        if store {
+            store_stats(&mut snapshot);
         }
 
         window_id += 1;
@@ -217,6 +223,85 @@ fn pubsub_stats(snapshot: &mut MetricsSnapshot) {
     let mut latencies = "Pubsub End-to-End Latency (us):".to_owned();
 
     for (label, _percentile, nanoseconds) in pubsub_latency {
+        let microseconds = nanoseconds / 1000;
+        latencies.push_str(&format!(" {label}: {microseconds}"))
+    }
+
+    output!("{latencies}");
+}
+
+/// Outputs store stats
+fn store_stats(snapshot: &mut MetricsSnapshot) {
+    let connect_ok = snapshot.counter_rate(STORE_CONNECT_OK_COUNTER);
+    let connect_ex = snapshot.counter_rate(STORE_CONNECT_EX_COUNTER);
+    let connect_timeout = snapshot.counter_rate(STORE_CONNECT_TIMEOUT_COUNTER);
+    let connect_total = snapshot.counter_rate(STORE_CONNECT_COUNTER);
+
+    let request_reconnect = snapshot.counter_rate(STORE_REQUEST_RECONNECT_COUNTER);
+    let request_ok = snapshot.counter_rate(STORE_REQUEST_OK_COUNTER);
+    let request_unsupported = snapshot.counter_rate(STORE_REQUEST_UNSUPPORTED_COUNTER);
+    let request_total = snapshot.counter_rate(STORE_REQUEST_COUNTER);
+
+    let response_ok = snapshot.counter_rate(STORE_RESPONSE_OK_COUNTER);
+    let response_ex = snapshot.counter_rate(STORE_RESPONSE_EX_COUNTER);
+    let response_timeout = snapshot.counter_rate(STORE_RESPONSE_TIMEOUT_COUNTER);
+    let response_found = snapshot.counter_rate(STORE_RESPONSE_FOUND_COUNTER);
+    let response_not_found = snapshot.counter_rate(STORE_RESPONSE_NOT_FOUND_COUNTER);
+
+    let connect_sr = 100.0 * connect_ok / connect_total;
+
+    let response_latency = snapshot.percentiles(STORE_RESPONSE_LATENCY_HISTOGRAM);
+
+    output!(
+        "Store Client Connection: Open: {} Success Rate: {:.2} %",
+        CONNECT_CURR.value(),
+        connect_sr
+    );
+    output!(
+        "Store Client Connection Rates (/s): Attempt: {:.2} Opened: {:.2} Errors: {:.2} Timeout: {:.2} Closed: {:.2}",
+        connect_total,
+        connect_ok,
+        connect_ex,
+        connect_timeout,
+        request_reconnect,
+    );
+
+    let request_sr = 100.0 * request_ok / request_total;
+    let request_ur = 100.0 * request_unsupported / request_total;
+
+    output!(
+        "Store Client Request: Success: {:.2} % Unsupported: {:.2} %",
+        request_sr,
+        request_ur,
+    );
+    output!(
+        "Store Client Request Rate (/s): Ok: {:.2} Unsupported: {:.2}",
+        request_ok,
+        request_unsupported,
+    );
+
+    let response_total = response_ok + response_ex + response_timeout;
+
+    let response_sr = 100.0 * response_ok / response_total;
+    let response_to = 100.0 * response_timeout / response_total;
+    let response_fr = 100.0 * response_found / (response_found + response_not_found);
+
+    output!(
+        "Store Client Response: Success: {:.2} % Timeout: {:.2} % Found: {:.2} %",
+        response_sr,
+        response_to,
+        response_fr,
+    );
+    output!(
+        "Store Client Response Rate (/s): Ok: {:.2} Error: {:.2} Timeout: {:.2}",
+        response_ok,
+        response_ex,
+        response_timeout,
+    );
+
+    let mut latencies = "Store Client Response Latency (us):".to_owned();
+
+    for (label, _percentile, nanoseconds) in response_latency {
         let microseconds = nanoseconds / 1000;
         latencies.push_str(&format!(" {label}: {microseconds}"))
     }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,0 +1,61 @@
+use crate::*;
+
+use ::momento::{MomentoError, MomentoErrorCode};
+use async_channel::Receiver;
+use std::io::{Error, ErrorKind, Result};
+use std::time::Instant;
+use tokio::runtime::Runtime;
+use workload::{ClientWorkItemKind, StoreClientRequest};
+
+mod momento;
+
+pub fn launch_store_clients(
+    config: &Config,
+    work_receiver: Receiver<ClientWorkItemKind<StoreClientRequest>>,
+) -> Option<Runtime> {
+    if config.storage().is_none() {
+        debug!("No store configuration specified");
+        return None;
+    }
+    debug!("Launching clients...");
+
+    config.storage()?;
+
+    // spawn the request drivers on their own runtime
+    let mut client_rt = Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(config.storage().unwrap().threads())
+        .build()
+        .expect("failed to initialize tokio runtime");
+
+    match config.general().protocol() {
+        Protocol::Momento => momento::launch_tasks(&mut client_rt, config.clone(), work_receiver),
+        _ => {
+            error!("momento protocol is the only supported store protocol");
+            std::process::exit(1);
+        }
+    }
+
+    Some(client_rt)
+}
+
+pub enum ResponseError {
+    /// Some exception while reading the response
+    Exception,
+    /// A timeout while awaiting the response
+    Timeout,
+    /// Some backends may have rate limits
+    Ratelimited,
+    /// Some backends may have their own timeout
+    BackendTimeout,
+}
+
+impl From<MomentoError> for ResponseError {
+    fn from(other: MomentoError) -> Self {
+        match other.error_code {
+            MomentoErrorCode::LimitExceededError { .. } => ResponseError::Ratelimited,
+            MomentoErrorCode::TimeoutError { .. } => ResponseError::BackendTimeout,
+            _ => ResponseError::Exception,
+        }
+    }
+}

--- a/src/store/momento.rs
+++ b/src/store/momento.rs
@@ -1,0 +1,210 @@
+use super::*;
+
+use ::momento::storage::configurations::LowLatency;
+use ::momento::*;
+
+use paste::paste;
+
+use ::momento::storage::PutRequest;
+use storage::GetResponse;
+use tokio::time::timeout;
+use workload::StoreClientRequest;
+
+/// Launch tasks with one channel per task as gRPC is mux-enabled.
+pub fn launch_tasks(
+    runtime: &mut Runtime,
+    config: Config,
+    work_receiver: Receiver<ClientWorkItemKind<StoreClientRequest>>,
+) {
+    debug!("launching momento protocol tasks");
+
+    for _ in 0..config.storage().unwrap().poolsize() {
+        let client = {
+            let _guard = runtime.enter();
+
+            // initialize the Momento cache client
+            if std::env::var("MOMENTO_API_KEY").is_err() {
+                eprintln!("environment variable `MOMENTO_API_KEY` is not set");
+                std::process::exit(1);
+            }
+
+            let credential_provider =
+                match CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string()) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        eprintln!("MOMENTO_API_KEY key should be valid: {e}");
+                        std::process::exit(1);
+                    }
+                };
+
+            match PreviewStorageClient::builder()
+                .configuration(LowLatency::latest())
+                .credential_provider(credential_provider)
+                .build()
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("could not create storage client: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        };
+
+        CONNECT.increment();
+        CONNECT_CURR.increment();
+
+        // create one task per channel
+        for _ in 0..config.storage().unwrap().concurrency() {
+            runtime.spawn(task(config.clone(), client.clone(), work_receiver.clone()));
+        }
+    }
+}
+
+async fn task(
+    config: Config,
+    mut client: PreviewStorageClient,
+    work_receiver: Receiver<ClientWorkItemKind<StoreClientRequest>>,
+) -> Result<()> {
+    let store_config = config.storage().unwrap_or_else(|| {
+        eprintln!("store configuration was not specified");
+        std::process::exit(1);
+    });
+    let store_name = store_config.store_name().unwrap_or_else(|| {
+        eprintln!("store name is not specified in the `store` section");
+        std::process::exit(1);
+    });
+
+    while RUNNING.load(Ordering::Relaxed) {
+        let work_item = work_receiver
+            .recv()
+            .await
+            .map_err(|_| Error::new(ErrorKind::Other, "channel closed"))?;
+
+        REQUEST.increment();
+        let start = Instant::now();
+        let result = match work_item {
+            ClientWorkItemKind::Request { request, .. } => match request {
+                /*
+                 * KEY-VALUE
+                 */
+                StoreClientRequest::Get(r) => store_get(&mut client, &config, store_name, r).await,
+                StoreClientRequest::Put(r) => put(&mut client, &config, store_name, r).await,
+                StoreClientRequest::Delete(r) => {
+                    store_delete(&mut client, &config, store_name, r).await
+                }
+                _ => {
+                    REQUEST_UNSUPPORTED.increment();
+                    continue;
+                }
+            },
+            ClientWorkItemKind::Reconnect => {
+                continue;
+            }
+        };
+
+        REQUEST_OK.increment();
+
+        let stop = Instant::now();
+
+        match result {
+            Ok(_) => {
+                RESPONSE_OK.increment();
+
+                let latency = stop.duration_since(start).as_nanos() as u64;
+
+                let _ = RESPONSE_LATENCY.increment(latency);
+            }
+            Err(ResponseError::Exception) => {
+                RESPONSE_EX.increment();
+            }
+            Err(ResponseError::Timeout) => {
+                RESPONSE_TIMEOUT.increment();
+            }
+            Err(ResponseError::Ratelimited) => {
+                RESPONSE_RATELIMITED.increment();
+            }
+            Err(ResponseError::BackendTimeout) => {
+                RESPONSE_BACKEND_TIMEOUT.increment();
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Puts a key-value pair in a store.
+pub async fn put(
+    client: &mut PreviewStorageClient,
+    config: &Config,
+    store_name: &str,
+    request: workload::store::Put,
+) -> std::result::Result<(), ResponseError> {
+    SET.increment();
+
+    let r = PutRequest::new(store_name, &*request.key, &*request.value);
+    let result = timeout(
+        config.storage().unwrap().request_timeout(),
+        client.send_request(r),
+    )
+    .await;
+
+    record_result!(result, SET, SET_STORED)
+}
+
+/// Retrieve a key-value pair from the store.
+pub async fn store_get(
+    client: &mut PreviewStorageClient,
+    config: &Config,
+    store_name: &str,
+    request: workload::store::Get,
+) -> std::result::Result<(), ResponseError> {
+    GET.increment();
+
+    match timeout(
+        config.storage().unwrap().request_timeout(),
+        client.get(store_name, &*request.key),
+    )
+    .await
+    {
+        Ok(Ok(r)) => match r {
+            GetResponse::Found { .. } => {
+                GET_OK.increment();
+                RESPONSE_HIT.increment();
+                GET_KEY_HIT.increment();
+                Ok(())
+            }
+            GetResponse::NotFound => {
+                GET_OK.increment();
+                RESPONSE_MISS.increment();
+                GET_KEY_MISS.increment();
+                Ok(())
+            }
+        },
+        Ok(Err(e)) => {
+            GET_EX.increment();
+            Err(e.into())
+        }
+        Err(_) => {
+            GET_TIMEOUT.increment();
+            Err(ResponseError::Timeout)
+        }
+    }
+}
+
+/// Remove a key from the store.
+pub async fn store_delete(
+    client: &mut PreviewStorageClient,
+    config: &Config,
+    store_name: &str,
+    request: workload::store::Delete,
+) -> std::result::Result<(), ResponseError> {
+    DELETE.increment();
+
+    let result = timeout(
+        config.storage().unwrap().request_timeout(),
+        client.delete(store_name, (*request.key).to_owned()),
+    )
+    .await;
+
+    record_result!(result, DELETE)
+}

--- a/src/workload/client.rs
+++ b/src/workload/client.rs
@@ -3,15 +3,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 #[derive(Debug, PartialEq)]
-pub enum ClientWorkItem {
-    Reconnect,
-    Request {
-        request: ClientRequest,
-        sequence: u64,
-    },
-}
-
-#[derive(Debug, PartialEq)]
 pub struct Ping {}
 
 #[derive(Debug, PartialEq)]

--- a/src/workload/mod.rs
+++ b/src/workload/mod.rs
@@ -227,7 +227,7 @@ impl Generator {
     ) -> ClientWorkItemKind<StoreClientRequest> {
         let command = &store.commands[store.command_dist.sample(rng)];
         let request = match command.verb() {
-            StoreVerb::Set => StoreClientRequest::Put(store::Put {
+            StoreVerb::Put => StoreClientRequest::Put(store::Put {
                 key: store.sample_string(rng),
                 value: store.gen_value(rng),
             }),
@@ -841,7 +841,7 @@ impl Store {
             // commands that set generated values need a `vlen`
             if store.vlen().is_none()
                 && store.vkind() == ValueKind::Bytes
-                && matches!(command.verb(), StoreVerb::Set)
+                && matches!(command.verb(), StoreVerb::Put)
             {
                 eprintln!(
                     "verb: {:?} requires that the keyspace has a `vlen` set when `vkind` is `bytes`",

--- a/src/workload/mod.rs
+++ b/src/workload/mod.rs
@@ -10,6 +10,7 @@ use rand_distr::WeightedAliasIndex;
 use rand_xoshiro::{Seed512, Xoshiro512PlusPlus};
 use ratelimit::Ratelimiter;
 use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
 use std::io::{Result, Write};
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
@@ -19,16 +20,20 @@ use zipf::ZipfDistribution;
 pub mod client;
 mod publisher;
 
-pub use client::{ClientRequest, ClientWorkItem};
+pub use client::ClientRequest;
 pub use publisher::PublisherWorkItem;
+
+pub mod store;
+pub use store::StoreClientRequest;
 
 static SEQUENCE_NUMBER: AtomicU64 = AtomicU64::new(0);
 
 pub fn launch_workload(
     generator: Generator,
     config: &Config,
-    client_sender: Sender<ClientWorkItem>,
+    client_sender: Sender<ClientWorkItemKind<ClientRequest>>,
     pubsub_sender: Sender<PublisherWorkItem>,
+    store_sender: Sender<ClientWorkItemKind<StoreClientRequest>>,
 ) -> Runtime {
     debug!("Launching workload...");
 
@@ -47,6 +52,7 @@ pub fn launch_workload(
     for _ in 0..config.workload().threads() {
         let client_sender = client_sender.clone();
         let pubsub_sender = pubsub_sender.clone();
+        let store_sender = store_sender.clone();
         let generator = generator.clone();
 
         // generate the seed for this workload thread
@@ -59,13 +65,15 @@ pub fn launch_workload(
             let mut rng = Xoshiro512PlusPlus::from_seed(Seed512(seed));
 
             while RUNNING.load(Ordering::Relaxed) {
-                generator.generate(&client_sender, &pubsub_sender, &mut rng);
+                generator.generate(&client_sender, &pubsub_sender, &store_sender, &mut rng);
             }
         });
     }
 
     let c = config.clone();
+    let store_c = config.clone();
     workload_rt.spawn_blocking(move || reconnect(client_sender, c));
+    workload_rt.spawn_blocking(move || reconnect(store_sender, store_c));
 
     workload_rt
 }
@@ -112,6 +120,11 @@ impl Generator {
             component_weights.push(topics.weight());
         }
 
+        for store in config.workload().stores() {
+            components.push(Component::Store(Store::new(config, store)));
+            component_weights.push(store.weight());
+        }
+
         if components.is_empty() {
             eprintln!("no workload components were specified in the config");
             std::process::exit(1);
@@ -130,8 +143,9 @@ impl Generator {
 
     pub fn generate(
         &self,
-        client_sender: &Sender<ClientWorkItem>,
+        client_sender: &Sender<ClientWorkItemKind<ClientRequest>>,
         pubsub_sender: &Sender<PublisherWorkItem>,
+        store_sender: &Sender<ClientWorkItemKind<StoreClientRequest>>,
         rng: &mut dyn RngCore,
     ) {
         if let Some(ref ratelimiter) = self.ratelimiter {
@@ -158,6 +172,14 @@ impl Generator {
             Component::Topics(topics) => {
                 if pubsub_sender
                     .try_send(self.generate_pubsub(topics, rng))
+                    .is_err()
+                {
+                    REQUEST_DROPPED.increment();
+                }
+            }
+            Component::Store(store) => {
+                if store_sender
+                    .try_send(self.generate_store_request(store, rng))
                     .is_err()
                 {
                     REQUEST_DROPPED.increment();
@@ -198,7 +220,36 @@ impl Generator {
         }
     }
 
-    fn generate_request(&self, keyspace: &Keyspace, rng: &mut dyn RngCore) -> ClientWorkItem {
+    fn generate_store_request(
+        &self,
+        store: &Store,
+        rng: &mut dyn RngCore,
+    ) -> ClientWorkItemKind<StoreClientRequest> {
+        let command = &store.commands[store.command_dist.sample(rng)];
+        let request = match command.verb() {
+            StoreVerb::Set => StoreClientRequest::Put(store::Put {
+                key: store.sample_string(rng),
+                value: store.gen_value(rng),
+            }),
+            StoreVerb::Get => StoreClientRequest::Get(store::Get {
+                key: store.sample_string(rng),
+            }),
+            StoreVerb::Delete => StoreClientRequest::Delete(store::Delete {
+                key: store.sample_string(rng),
+            }),
+            StoreVerb::Ping => StoreClientRequest::Ping(store::Ping {}),
+        };
+        ClientWorkItemKind::Request {
+            request,
+            sequence: SEQUENCE_NUMBER.fetch_add(1, Ordering::Relaxed),
+        }
+    }
+
+    fn generate_request(
+        &self,
+        keyspace: &Keyspace,
+        rng: &mut dyn RngCore,
+    ) -> ClientWorkItemKind<ClientRequest> {
         let command = &keyspace.commands[keyspace.command_dist.sample(rng)];
 
         let request = match command.verb() {
@@ -394,7 +445,7 @@ impl Generator {
             }),
         };
 
-        ClientWorkItem::Request {
+        ClientWorkItemKind::Request {
             request,
             sequence: SEQUENCE_NUMBER.fetch_add(1, Ordering::Relaxed),
         }
@@ -409,6 +460,7 @@ impl Generator {
 pub enum Component {
     Keyspace(Keyspace),
     Topics(Topics),
+    Store(Store),
 }
 
 #[derive(Clone)]
@@ -686,7 +738,6 @@ impl Keyspace {
         }
 
         let command_dist = WeightedAliasIndex::new(command_weights).unwrap();
-
         Self {
             keys,
             key_dist,
@@ -727,7 +778,123 @@ impl Keyspace {
     }
 }
 
-pub async fn reconnect(work_sender: Sender<ClientWorkItem>, config: Config) -> Result<()> {
+#[derive(Clone)]
+pub struct Store {
+    keys: Vec<Arc<[u8]>>,
+    key_dist: Distribution,
+    commands: Vec<StoreCommand>,
+    command_dist: WeightedAliasIndex<usize>,
+    vlen: usize,
+    vkind: ValueKind,
+    value_random_bytes: usize,
+}
+
+impl Store {
+    pub fn new(config: &Config, store: &config::Store) -> Self {
+        let value_random_bytes =
+            estimate_random_bytes_needed(store.vlen().unwrap_or(0), store.compression_ratio());
+
+        // nkeys must be >= 1
+        let nkeys = std::cmp::max(1, store.nkeys());
+        let klen = store.klen();
+
+        // initialize a PRNG with the default initial seed
+        let mut rng = Xoshiro512PlusPlus::from_seed(config.general().initial_seed());
+
+        // generate the seed for key PRNG
+        let mut raw_seed = [0_u8; 64];
+        rng.fill_bytes(&mut raw_seed);
+        let key_seed = Seed512(raw_seed);
+
+        // generate the seed for inner key PRNG
+        let mut raw_seed = [0_u8; 64];
+        rng.fill_bytes(&mut raw_seed);
+
+        // we use a predictable seed to generate the keys in the store
+        let mut rng = Xoshiro512PlusPlus::from_seed(key_seed);
+        let mut keys = HashSet::with_capacity(nkeys);
+        while keys.len() < nkeys {
+            let key = (&mut rng)
+                .sample_iter(&Alphanumeric)
+                .take(klen)
+                .collect::<Vec<u8>>();
+            let _ = keys.insert(key);
+        }
+        let keys = keys.drain().map(|k| k.into()).collect();
+        let key_dist = match store.key_distribution() {
+            config::Distribution::Uniform => Distribution::Uniform(Uniform::new(0, nkeys)),
+            config::Distribution::Zipf => {
+                Distribution::Zipf(ZipfDistribution::new(nkeys, 1.0).unwrap())
+            }
+        };
+
+        let mut commands = Vec::new();
+        let mut command_weights = Vec::new();
+
+        for command in store.commands() {
+            commands.push(*command);
+            command_weights.push(command.weight());
+
+            // validate that the store is adaquately specified for the given
+            // verb
+
+            // commands that set generated values need a `vlen`
+            if store.vlen().is_none()
+                && store.vkind() == ValueKind::Bytes
+                && matches!(command.verb(), StoreVerb::Set)
+            {
+                eprintln!(
+                    "verb: {:?} requires that the keyspace has a `vlen` set when `vkind` is `bytes`",
+                    command.verb()
+                );
+                std::process::exit(2);
+            }
+        }
+
+        let command_dist = WeightedAliasIndex::new(command_weights).unwrap();
+        Self {
+            keys,
+            key_dist,
+            commands,
+            command_dist,
+            vlen: store.vlen().unwrap_or(0),
+            vkind: store.vkind(),
+            value_random_bytes,
+        }
+    }
+
+    pub fn sample(&self, rng: &mut dyn RngCore) -> Arc<[u8]> {
+        let index = self.key_dist.sample(rng);
+        self.keys[index].clone()
+    }
+
+    pub fn sample_string(&self, rng: &mut dyn RngCore) -> Arc<String> {
+        let keys = self.sample(rng);
+        Arc::new(String::from_utf8_lossy(&keys).into_owned())
+    }
+
+    pub fn gen_value(&self, rng: &mut dyn RngCore) -> Vec<u8> {
+        match self.vkind {
+            ValueKind::I64 => format!("{}", rng.gen::<i64>()).into_bytes(),
+            ValueKind::Bytes => {
+                let mut buf = vec![0_u8; self.vlen];
+                rng.fill(&mut buf[0..self.value_random_bytes]);
+                buf
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ClientWorkItemKind<T> {
+    Reconnect,
+    Request { request: T, sequence: u64 },
+}
+
+pub async fn reconnect<TRequestKind>(
+    work_sender: Sender<ClientWorkItemKind<TRequestKind>>,
+    config: Config,
+) -> Result<()> {
     if config.client().is_none() {
         return Ok(());
     }
@@ -761,7 +928,7 @@ pub async fn reconnect(work_sender: Sender<ClientWorkItem>, config: Config) -> R
     while RUNNING.load(Ordering::Relaxed) {
         match ratelimiter.try_wait() {
             Ok(_) => {
-                let _ = work_sender.send(ClientWorkItem::Reconnect).await;
+                let _ = work_sender.send(ClientWorkItemKind::Reconnect).await;
             }
             Err(d) => {
                 std::thread::sleep(d);

--- a/src/workload/store.rs
+++ b/src/workload/store.rs
@@ -1,0 +1,36 @@
+use std::sync::Arc;
+
+#[derive(Debug, PartialEq)]
+pub struct Ping {}
+
+#[derive(Debug, PartialEq)]
+pub struct Get {
+    pub key: Arc<String>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Delete {
+    pub key: Arc<String>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Put {
+    /// For a Momento PUT request to a store, keys will always be
+    /// a `String` type.
+    pub key: Arc<String>,
+    pub value: Vec<u8>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, PartialEq)]
+pub enum StoreClientRequest {
+    // Ping
+    Ping(Ping),
+
+    // Key-Value
+    Get(Get),
+    Delete(Delete),
+    Put(Put),
+
+    Reconnect,
+}


### PR DESCRIPTION
Problem

* Momento client needs to be updated to `v0.42.0`
* Need support for Momento `store` workflow
    * Unlike Redis/Memcache/Momento cache, a `store` is a high-performance, low-latency storage system for storing persistent items
    * Unlike Redis/Memcache/Momento cache, the amount of APIs a Momento `store` supports is very small for now: get/set/delete
* Need support to have a `storage` workflow run simultaneously to a `cache` workflow

Solution

* Upgraded Momento client
* Added support for a separate `storage` client config. `client` and `storage` should not share the same config settings
* Added support for separate `store` workflow(s), only supporting the Momento protocol (for now).
* DRY'd up the `WorkItem` typing so that reconnection code can be reused between the `cache` client and `store` client code, but the distinct enum per work item type remains distinct. This ensures there is still compile-time checks for the right enum being sent to a `Receiver<T>` (see https://github.com/iopsystems/rpc-perf/pull/240/files#r1680025693)

Result

Built binary and deployed to a local testing environment, running with _only_ a store config. Example config:

```toml
[general]
# specify the protocol to be used
protocol = "momento"
# the interval for stats integration and reporting
interval = 60
# the number of intervals to run the test for
duration = 3600
# optionally, we can write some detailed stats to a file during the run
#json_output = "stats.json"
# run the admin thread with a HTTP listener at the address provided, this allows
# stats exposition via HTTP
admin = "127.0.0.1:4444"

[debug]
# choose from: error, warn, info, debug, trace
log_level = "info"
# optionally, log to the file below instead of standard out
# log_file = "rpc-perf.log"
# backup file name for use with log rotation
log_backup = "rpc-perf.log.old"
# trigger log rotation when the file grows beyond this size (in bytes). Set this
# option to '0' to disable log rotation.
log_max_size = 1073741824

[target]
# we don't need to specify any endpoints for momento
endpoints = []

[storage]
# number of threads used to drive client requests
threads = 4
# number of gRPC clients to initialize, each maintains at least one TCP stream
poolsize = 43
# an upper limit on the number of concurrent requests per gRPC client
concurrency = 20
# the connect timeout in milliseconds
connect_timeout = 1000
# set the timeout in milliseconds
request_timeout = 1000
store_name = "my-store"

[workload]
# the number of threads that will be used to generate the workload
threads = 1

[workload.ratelimit]
# set a global ratelimit for the workload
start = 20_000


# Note that we can constrain the number of keys in the keyspace and specify that
# the generated values are random bytes with 128B values.
[[workload.stores]]
# sets the relative weight of this keyspace: defaults to 1
weight = 1
# sets the length of the key, in bytes
klen = 100
# sets the number of keys that will be generated
nkeys = 10_000
# sets the value length, in bytes
vlen = 4000
# use random bytes for the values
vkind = "bytes"
# controls what commands will be used in this keyspace
commands = [
    { verb = "get", weight = 1 },
    { verb = "set", weight = 1 },
]

```

Upon executing the newly generated binary, I could confirm that the `store` workflow successfully exercised traffic and recorded expected metrics a distinct `SET` and `GET` metrics.

