### PR TITLE
use macos-latest for github macos runner image

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-12 ]
+        os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-rust
@@ -110,7 +110,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-12 ]
+        os: [ ubuntu-latest, macos-latest ]
         profile: [ release, debug ]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Updates the CI config to use macos-latest for the runner image
