### PR TITLE
fix redis SET command

### DIFF
--- a/src/clients/cache/redis/commands/set.rs
+++ b/src/clients/cache/redis/commands/set.rs
@@ -17,17 +17,13 @@ pub async fn set(
 
     if let Some(ttl) = request.ttl {
         if ttl.subsec_nanos() == 0 {
-            command = base_command
-                .arg(key)
+            command = command
                 .arg("EX")
-                .arg(ttl.as_secs())
-                .arg(value);
+                .arg(ttl.as_secs());
         } else {
-            command = base_command
-                .arg(key)
+            command = command
                 .arg("PX")
-                .arg(ttl.as_millis() as u64)
-                .arg(value);
+                .arg(ttl.as_millis() as u64);
         }
     }
 

--- a/src/clients/cache/redis/commands/set.rs
+++ b/src/clients/cache/redis/commands/set.rs
@@ -17,13 +17,9 @@ pub async fn set(
 
     if let Some(ttl) = request.ttl {
         if ttl.subsec_nanos() == 0 {
-            command = command
-                .arg("EX")
-                .arg(ttl.as_secs());
+            command = command.arg("EX").arg(ttl.as_secs());
         } else {
-            command = command
-                .arg("PX")
-                .arg(ttl.as_millis() as u64);
+            command = command.arg("PX").arg(ttl.as_millis() as u64);
         }
     }
 


### PR DESCRIPTION
I was getting `syntax error` when running load test against Redis with SET commands.
There was a bug where we used an incorrect SET syntax.