### PR TITLE
avoid request burst on ratelimit changes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -136,9 +136,9 @@ fn main() {
     }
 
     // TODO: figure out what a reasonable size is here
-    let (client_sender, client_receiver) = bounded(128);
-    let (pubsub_sender, pubsub_receiver) = bounded(128);
-    let (store_sender, store_receiver) = bounded(128);
+    let (client_sender, client_receiver) = bounded(config.client().map(|c| c.threads()).unwrap_or(1));
+    let (pubsub_sender, pubsub_receiver) = bounded(config.pubsub().map(|c| c.publisher_threads()).unwrap_or(1));
+    let (store_sender, store_receiver) = bounded(config.storage().map(|c| c.threads()).unwrap_or(1));
 
     output!("Protocol: {:?}", config.general().protocol());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,9 +136,12 @@ fn main() {
     }
 
     // TODO: figure out what a reasonable size is here
-    let (client_sender, client_receiver) = bounded(config.client().map(|c| c.threads()).unwrap_or(1));
-    let (pubsub_sender, pubsub_receiver) = bounded(config.pubsub().map(|c| c.publisher_threads()).unwrap_or(1));
-    let (store_sender, store_receiver) = bounded(config.storage().map(|c| c.threads()).unwrap_or(1));
+    let (client_sender, client_receiver) =
+        bounded(config.client().map(|c| c.threads()).unwrap_or(1));
+    let (pubsub_sender, pubsub_receiver) =
+        bounded(config.pubsub().map(|c| c.publisher_threads()).unwrap_or(1));
+    let (store_sender, store_receiver) =
+        bounded(config.storage().map(|c| c.threads()).unwrap_or(1));
 
     output!("Protocol: {:?}", config.general().protocol());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,8 +138,12 @@ fn main() {
     // TODO: figure out what a reasonable size is here
     let (client_sender, client_receiver) =
         bounded(config.client().map(|c| c.threads() * 2).unwrap_or(1));
-    let (pubsub_sender, pubsub_receiver) =
-        bounded(config.pubsub().map(|c| c.publisher_threads() * 2).unwrap_or(1));
+    let (pubsub_sender, pubsub_receiver) = bounded(
+        config
+            .pubsub()
+            .map(|c| c.publisher_threads() * 2)
+            .unwrap_or(1),
+    );
     let (store_sender, store_receiver) =
         bounded(config.storage().map(|c| c.threads() * 2).unwrap_or(1));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,11 +137,11 @@ fn main() {
 
     // TODO: figure out what a reasonable size is here
     let (client_sender, client_receiver) =
-        bounded(config.client().map(|c| c.threads()).unwrap_or(1));
+        bounded(config.client().map(|c| c.threads() * 2).unwrap_or(1));
     let (pubsub_sender, pubsub_receiver) =
-        bounded(config.pubsub().map(|c| c.publisher_threads()).unwrap_or(1));
+        bounded(config.pubsub().map(|c| c.publisher_threads() * 2).unwrap_or(1));
     let (store_sender, store_receiver) =
-        bounded(config.storage().map(|c| c.threads()).unwrap_or(1));
+        bounded(config.storage().map(|c| c.threads() * 2).unwrap_or(1));
 
     output!("Protocol: {:?}", config.general().protocol());
 

--- a/src/workload/mod.rs
+++ b/src/workload/mod.rs
@@ -97,11 +97,9 @@ impl Generator {
             // ratelimits.
             let interval = Duration::from_nanos(1_000_000_000 / (rate / amount));
 
-            let capacity = std::cmp::max(100, amount);
-
             Arc::new(
                 Ratelimiter::builder(amount, interval)
-                    .max_tokens(capacity)
+                    .max_tokens(amount)
                     .build()
                     .expect("failed to initialize ratelimiter"),
             )
@@ -909,11 +907,9 @@ pub async fn reconnect<TRequestKind>(
         // ratelimits.
         let interval = Duration::from_nanos(1_000_000_000 / (rate / amount));
 
-        let capacity = std::cmp::max(100, amount);
-
         Arc::new(
             Ratelimiter::builder(amount, interval)
-                .max_tokens(capacity)
+                .max_tokens(amount)
                 .build()
                 .expect("failed to initialize ratelimiter"),
         )

--- a/src/workload/mod.rs
+++ b/src/workload/mod.rs
@@ -99,7 +99,7 @@ impl Generator {
 
             Arc::new(
                 Ratelimiter::builder(amount, interval)
-                    .max_tokens(amount)
+                    .max_tokens(amount * 8)
                     .build()
                     .expect("failed to initialize ratelimiter"),
             )
@@ -909,7 +909,7 @@ pub async fn reconnect<TRequestKind>(
 
         Arc::new(
             Ratelimiter::builder(amount, interval)
-                .max_tokens(amount)
+                .max_tokens(amount * 8)
                 .build()
                 .expect("failed to initialize ratelimiter"),
         )


### PR DESCRIPTION
To avoid an intial burst of requests when load level is increased the work queues have had their capacity reduced and the ratelimiter max tokens is set to the batch size.
