### PR TITLE
fix for momento http with large payloads

### DIFF
--- a/src/clients/cache/momento/http.rs
+++ b/src/clients/cache/momento/http.rs
@@ -1,7 +1,7 @@
-use rustls::KeyLogFile;
 use crate::clients::common::*;
 use crate::workload::{ClientRequest, ClientWorkItemKind};
 use crate::*;
+use rustls::KeyLogFile;
 
 use async_channel::Receiver;
 use bytes::{Bytes, BytesMut};
@@ -205,7 +205,12 @@ async fn task(
                                 if let Ok(b) = chunk {
                                     // info!("chunk for get: ({}) {}", std::str::from_utf8(&r.key).unwrap(), b.len());
                                     buffer.extend_from_slice(&b);
-                                    if response.body_mut().flow_control().release_capacity(b.len()).is_err() {
+                                    if response
+                                        .body_mut()
+                                        .flow_control()
+                                        .release_capacity(b.len())
+                                        .is_err()
+                                    {
                                         // info!("error releasing capacity");
                                         GET_EX.increment();
 
@@ -312,7 +317,12 @@ async fn task(
                             if let Ok(b) = chunk {
                                 // info!("chunk for set: {}", b.len());
                                 buffer.extend_from_slice(&b);
-                                if response.body_mut().flow_control().release_capacity(b.len()).is_err() {
+                                if response
+                                    .body_mut()
+                                    .flow_control()
+                                    .release_capacity(b.len())
+                                    .is_err()
+                                {
                                     // info!("error releasing capacity");
                                     SET_EX.increment();
 
@@ -320,7 +330,6 @@ async fn task(
 
                                     continue;
                                 }
-
                             } else {
                                 SET_EX.increment();
 
@@ -395,7 +404,12 @@ async fn task(
                                 if let Ok(b) = chunk {
                                     // info!("chunk for delete: {}", b.len());
                                     buffer.extend_from_slice(&b);
-                                    if response.body_mut().flow_control().release_capacity(b.len()).is_err() {
+                                    if response
+                                        .body_mut()
+                                        .flow_control()
+                                        .release_capacity(b.len())
+                                        .is_err()
+                                    {
                                         // info!("error releasing capacity");
                                         DELETE_EX.increment();
 

--- a/src/clients/cache/momento/http.rs
+++ b/src/clients/cache/momento/http.rs
@@ -83,9 +83,6 @@ pub async fn pool_manager(endpoint: String, _config: Config, queue: Queue<SendRe
                         .unwrap();
 
                     let client_builder = ::h2::client::Builder::new()
-                        // .initial_window_size(32 * 1024 * 1024)
-                        // .initial_connection_window_size(32 * 1024 * 1024)
-                        // .max_frame_size(8 * 1024 * 1024)
                         .handshake(stream);
 
                     if let Ok((h2, connection)) = client_builder.await {
@@ -203,7 +200,6 @@ async fn task(
 
                             while let Some(chunk) = response.body_mut().data().await {
                                 if let Ok(b) = chunk {
-                                    // info!("chunk for get: ({}) {}", std::str::from_utf8(&r.key).unwrap(), b.len());
                                     buffer.extend_from_slice(&b);
                                     if response
                                         .body_mut()
@@ -211,17 +207,12 @@ async fn task(
                                         .release_capacity(b.len())
                                         .is_err()
                                     {
-                                        // info!("error releasing capacity");
                                         GET_EX.increment();
 
                                         RESPONSE_EX.increment();
 
                                         continue;
                                     }
-
-                                    // if body.is_end_stream() {
-                                    //     info!("end of stream");
-                                    // }
                                 } else {
                                     GET_EX.increment();
 
@@ -230,8 +221,6 @@ async fn task(
                                     continue;
                                 }
                             }
-
-                            // info!("get complete");
 
                             let latency = start.elapsed();
 
@@ -307,8 +296,6 @@ async fn task(
 
                         let status = response.status().as_u16();
 
-                        // info!("set status: {status}");
-
                         // read the response body to completion
 
                         let mut buffer = BytesMut::new();
@@ -323,7 +310,6 @@ async fn task(
                                     .release_capacity(b.len())
                                     .is_err()
                                 {
-                                    // info!("error releasing capacity");
                                     SET_EX.increment();
 
                                     RESPONSE_EX.increment();
@@ -338,8 +324,6 @@ async fn task(
                                 continue;
                             }
                         }
-
-                        // info!("set complete");
 
                         let latency = start.elapsed();
 
@@ -394,15 +378,12 @@ async fn task(
 
                             let status = response.status().as_u16();
 
-                            // info!("delete status: {status}");
-
                             // read the response body to completion
 
                             let mut buffer = BytesMut::new();
 
                             while let Some(chunk) = response.body_mut().data().await {
                                 if let Ok(b) = chunk {
-                                    // info!("chunk for delete: {}", b.len());
                                     buffer.extend_from_slice(&b);
                                     if response
                                         .body_mut()
@@ -410,9 +391,7 @@ async fn task(
                                         .release_capacity(b.len())
                                         .is_err()
                                     {
-                                        // info!("error releasing capacity");
                                         DELETE_EX.increment();
-
                                         RESPONSE_EX.increment();
 
                                         continue;
@@ -425,8 +404,6 @@ async fn task(
                                     continue;
                                 }
                             }
-
-                            // info!("delete complete");
 
                             let latency = start.elapsed();
 

--- a/src/clients/cache/momento/http.rs
+++ b/src/clients/cache/momento/http.rs
@@ -82,8 +82,7 @@ pub async fn pool_manager(endpoint: String, _config: Config, queue: Queue<SendRe
                         .await
                         .unwrap();
 
-                    let client_builder = ::h2::client::Builder::new()
-                        .handshake(stream);
+                    let client_builder = ::h2::client::Builder::new().handshake(stream);
 
                     if let Ok((h2, connection)) = client_builder.await {
                         tokio::spawn(async move {


### PR DESCRIPTION
Fixes the handling of large http payloads with the Momento HTTP API by making sure we release capacity back to the connection and stream when each chunk is read.

Adds the ability to log TLS keys to a key log file for easier troubleshooting with packet captures.
