### PR TITLE
allow port number to be specified for momento_http protocol

### DIFF
--- a/src/clients/cache/momento/http.rs
+++ b/src/clients/cache/momento/http.rs
@@ -76,9 +76,8 @@ pub async fn pool_manager(endpoint: String, _config: Config, queue: Queue<SendRe
                     }
 
                     let connector: TlsConnector = TlsConnector::from(config.clone());
-
                     let stream = connector
-                        .connect(ServerName::try_from(auth.to_string()).unwrap(), tcp)
+                        .connect(ServerName::try_from(auth.host().to_string()).unwrap(), tcp)
                         .await
                         .unwrap();
 


### PR DESCRIPTION
Previously we would get InvalidDnsNameError error if we specified the port number for momento_http, e.g.
endpoints = ["https://api.cache.developer-vir-dev.preprod.a.momentohq.com:9003"]
