### PR TITLE
remove error log message when channel is closed

### DIFF
--- a/src/clients/cache/momento/http.rs
+++ b/src/clients/cache/momento/http.rs
@@ -155,9 +155,11 @@ async fn task(
 
         let work_item = match work_receiver.recv().await {
             Ok(w) => w,
-            Err(e) => {
-                error!("error while attempting to receive work item: {e}");
-                continue;
+            Err(_) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "channel closed",
+                ));
             }
         };
 


### PR DESCRIPTION
Removes the error log message when the channel is closed. This can occur at the end of a run and is not a true error.
