### PR TITLE
debugging startup times

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,7 @@ fn main() {
     // begin cli output
     control_runtime.spawn(output::log(config.clone()));
 
+    debug!("Running workload generator");
     // start the workload generator(s)
     let workload_runtime = launch_workload(
         workload_generator,
@@ -191,6 +192,7 @@ fn main() {
         oltp_sender,
     );
 
+    debug!("Starting clients");
     // start client(s)
     let client_runtime = clients::cache::launch(&config, client_receiver);
 
@@ -221,6 +223,7 @@ fn main() {
         }
     }
 
+    debug!("Waiting for test to complete");
     while RUNNING.load(Ordering::Relaxed) {
         std::thread::sleep(Duration::from_secs(1));
     }

--- a/src/workload/mod.rs
+++ b/src/workload/mod.rs
@@ -794,7 +794,12 @@ impl Keyspace {
         let len = 100 * 1024 * 1024;
         let mut vbuf = BytesMut::zeroed(len);
         rng.fill_bytes(&mut vbuf[0..value_random_bytes]);
-        vbuf.shuffle(&mut rng);
+
+        // if we have compressible values, we need to distribute the remaining
+        // zeros evenly across the value buffer
+        if vbuf.len() > value_random_bytes {
+            vbuf.shuffle(&mut rng);
+        }
 
         let command_dist = WeightedAliasIndex::new(command_weights).unwrap();
 


### PR DESCRIPTION
Adds some debug level log messages during startup to make it easier to see what phase of startup is taking a long time.

Avoids the value buffer shuffle when non-compressible values have been used.
