### PR TITLE
feat: allow overriding endpoint for momento clients

### DIFF
--- a/src/clients/cache/momento/mod.rs
+++ b/src/clients/cache/momento/mod.rs
@@ -28,7 +28,7 @@ pub fn launch_tasks(
                 std::process::exit(1);
             }
 
-            let credential_provider =
+            let mut credential_provider =
                 match CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string()) {
                     Ok(v) => v,
                     Err(e) => {
@@ -36,6 +36,10 @@ pub fn launch_tasks(
                         std::process::exit(1);
                     }
                 };
+            if let Ok(endpoint) = std::env::var("MOMENTO_ENDPOINT_OVERRIDE") {
+                credential_provider = credential_provider.base_endpoint(&endpoint);
+            }
+
             match CacheClient::builder()
                 .default_ttl(Duration::from_secs(900))
                 .configuration(LowLatency::v1())

--- a/src/clients/leaderboard/momento.rs
+++ b/src/clients/leaderboard/momento.rs
@@ -44,7 +44,7 @@ pub fn launch_tasks(
                 std::process::exit(1);
             }
 
-            let credential_provider =
+            let mut credential_provider =
                 match CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string()) {
                     Ok(v) => v,
                     Err(e) => {
@@ -52,7 +52,9 @@ pub fn launch_tasks(
                         std::process::exit(1);
                     }
                 };
-
+            if let Ok(endpoint) = std::env::var("MOMENTO_ENDPOINT_OVERRIDE") {
+                credential_provider = credential_provider.base_endpoint(&endpoint);
+            }
             match LeaderboardClient::builder()
                 .configuration(configurations::LowLatency::v1())
                 .credential_provider(credential_provider)

--- a/src/clients/pubsub/momento.rs
+++ b/src/clients/pubsub/momento.rs
@@ -56,7 +56,7 @@ pub fn launch_subscribers(
                         std::process::exit(1);
                     }
 
-                    let credential_provider =
+                    let mut credential_provider =
                         match CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string()) {
                             Ok(v) => v,
                             Err(e) => {
@@ -64,6 +64,9 @@ pub fn launch_subscribers(
                                 std::process::exit(1);
                             }
                         };
+                    if let Ok(endpoint) = std::env::var("MOMENTO_ENDPOINT_OVERRIDE") {
+                        credential_provider = credential_provider.base_endpoint(&endpoint);
+                    }
                     let _guard = runtime.enter();
                     match TopicClient::builder()
                         .configuration(LowLatency::v1())
@@ -156,7 +159,7 @@ pub fn launch_publishers(runtime: &mut Runtime, config: Config, work_receiver: R
                 std::process::exit(1);
             }
 
-            let credential_provider =
+            let mut credential_provider =
                 match CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string()) {
                     Ok(v) => v,
                     Err(e) => {
@@ -164,7 +167,9 @@ pub fn launch_publishers(runtime: &mut Runtime, config: Config, work_receiver: R
                         std::process::exit(1);
                     }
                 };
-
+            if let Ok(endpoint) = std::env::var("MOMENTO_ENDPOINT_OVERRIDE") {
+                credential_provider = credential_provider.base_endpoint(&endpoint);
+            }
             match TopicClient::builder()
                 .configuration(LowLatency::v1())
                 .credential_provider(credential_provider)

--- a/src/clients/store/momento.rs
+++ b/src/clients/store/momento.rs
@@ -32,7 +32,7 @@ pub fn launch_tasks(
                 std::process::exit(1);
             }
 
-            let credential_provider =
+            let mut credential_provider =
                 match CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string()) {
                     Ok(v) => v,
                     Err(e) => {
@@ -40,6 +40,9 @@ pub fn launch_tasks(
                         std::process::exit(1);
                     }
                 };
+            if let Ok(endpoint) = std::env::var("MOMENTO_ENDPOINT_OVERRIDE") {
+                credential_provider = credential_provider.base_endpoint(&endpoint);
+            }
 
             match PreviewStorageClient::builder()
                 .configuration(LowLatency::latest())


### PR DESCRIPTION
Problem
For local testing, we need the ability to talk to momento on a different domain name or port.

Solution

Allow overriding the endpoint via an environment variable