### PR TITLE
fix: replay mode fixes for metrics, log and config validation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,7 @@ fn main() {
         control_runtime.spawn(output::metrics(config.clone()));
 
         // begin cli output
-        control_runtime.spawn(output::log(config.clone()));
+        control_runtime.spawn(output::log(config.clone(), true));
 
         debug!("Launching replay clients");
         let replay_runtime = clients::cache::launch(&config, replay_receiver);
@@ -235,7 +235,7 @@ fn main() {
     control_runtime.spawn(output::metrics(config.clone()));
 
     // begin cli output
-    control_runtime.spawn(output::log(config.clone()));
+    control_runtime.spawn(output::log(config.clone(), false));
 
     debug!("Running workload generator");
     // start the workload generator(s)

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,6 +146,11 @@ fn main() {
 
     // switch into replay mode if the replay subcommand is provided
     if matches.subcommand_matches("replay").is_some() {
+        if config.replay().is_none() {
+            eprintln!("replay configuration section is required for replay mode");
+            std::process::exit(1);
+        }
+
         info!("Starting replay mode");
         let (replay_sender, replay_receiver) = bounded(
             config

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,9 @@ fn main() {
                 .unwrap_or(1),
         );
 
+        // spawn the admin thread
+        control_runtime.spawn(admin::http(config.clone(), None));
+
         // launch metrics file output
         control_runtime.spawn(output::metrics(config.clone()));
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -19,7 +19,7 @@ macro_rules! output {
     }};
 }
 
-pub async fn log(config: Config) {
+pub async fn log(config: Config, is_replay_mode: bool) {
     WAIT.fetch_add(1, Ordering::Relaxed);
 
     let mut window_id = 0;
@@ -28,7 +28,7 @@ pub async fn log(config: Config) {
     tokio::time::sleep(Duration::from_secs(1)).await;
     snapshot.update();
 
-    let client = !config.workload().keyspaces().is_empty();
+    let client = !config.workload().keyspaces().is_empty() || is_replay_mode;
     let pubsub = !config.workload().topics().is_empty();
     let store = !config.workload().stores().is_empty();
     let leaderboard = !config.workload().leaderboards().is_empty();


### PR DESCRIPTION
Problem

1. The http endpoint to scrape metrics from was not available when running in replay mode.
2. Log output was empty in replay mode
3. rpc-perf panics if replay config is entirely missing but replay subcommand is provided

Solution
I made targeted fixes for each issue in this PR but I think an overall refactor of the replay mode config is needed. I would like to see the replay config merged into the `workload` config section and have it choose between the command log input or generate values randomly. I don't have the bandwidth for that right now though.