### PR TITLE
feat: re-land get_batch command with bugfix

### DIFF
--- a/configs/momento.toml
+++ b/configs/momento.toml
@@ -139,7 +139,7 @@ commands = [
 	{ verb = "dictionary_set", weight = 5, cardinality = 5 },
 
 	# delete an entire dictionary
-	{ verb = "delete", weight = 5 }
+	{ verb = "delete", weight = 5 },
 ]
 
 # An example keyspace showcasing the use of the `list` family of commands.
@@ -270,13 +270,45 @@ commands = [
 	{ verb = "set_add_element", weight = 5, cardinality = 5 },
 
 	# retrieve all elements in the set
-	{ verb = "set_fetch", weight = 20},
+	{ verb = "set_fetch", weight = 20 },
 
 	# remove an element from the set
-	{ verb = "set_remove_element", weight = 5},
+	{ verb = "set_remove_element", weight = 5 },
 	# set the cardinality > 1 to remove multiple elements
 	{ verb = "set_remove_element", weight = 5, cardinality = 5 },
 
 	# remove an entire set with delete
-	{ verb = "delete", weight = 5 }
+	{ verb = "delete", weight = 5 },
+]
+
+# An example keyspace showcasing the use of the get-batch command.
+#
+# Note that we can constrain the number of keys in the keyspace and specify that
+# the generated values are random bytes with 128B values.
+[[workload.keyspace]]
+# sets the relative weight of this keyspace: defaults to 1
+weight = 1
+# sets the length of the key, in bytes
+klen = 32
+# sets the number of keys that will be generated
+nkeys = 1_000_000
+# sets the value length, in bytes
+vlen = 128
+# optionally, specify an approximate compression ratio for the value payload.
+# Defaults to 1.0 meaning the message is high-entropy and not compressible.
+compression_ratio = 1.0
+# use random bytes for the values
+vkind = "bytes"
+# override the default ttl for this keyspace setting it to 15 minutes
+ttl = "15m"
+# controls what commands will be used in this keyspace
+commands = [
+	# 65% of get batch requests consist of 6 items
+	{ verb = "get_batch", weight = 65, cardinality = 6 },
+	# 30% of get batch requests consist of 20 items
+	{ verb = "get_batch", weight = 30, cardinality = 20 },
+	# 4% of get batch requests consist of 50 items
+	{ verb = "get_batch", weight = 4, cardinality = 50 },
+	# 1% of get batch requests consist of 200 items
+	{ verb = "get_batch", weight = 1, cardinality = 200 },
 ]

--- a/src/clients/cache/momento/commands/get_batch.rs
+++ b/src/clients/cache/momento/commands/get_batch.rs
@@ -1,0 +1,33 @@
+use super::*;
+
+use ::momento::cache::GetBatchRequest;
+
+pub async fn get_batch(
+    client: &mut CacheClient,
+    config: &Config,
+    cache_name: &str,
+    request: workload::client::GetBatch,
+) -> std::result::Result<(), ResponseError> {
+    if request.keys.is_empty() {
+        return Ok(());
+    }
+
+    GETS.increment();
+
+    // Record batch size in metrics
+    let num_keys = request.keys.len() as u64;
+    GETS_KEY.add(num_keys);
+    let _ = GETS_CARDINALITY.increment(num_keys);
+    let _ = KVGETBATCH_BATCH_SIZE.increment(num_keys);
+
+    let keys: Vec<&[u8]> = request.keys.iter().map(|k| k.as_ref()).collect();
+    let r = GetBatchRequest::new(cache_name, keys);
+
+    let result = timeout(
+        config.client().unwrap().request_timeout(),
+        client.send_request(r),
+    )
+    .await;
+
+    record_result!(result, GET)
+}

--- a/src/clients/cache/momento/commands/mod.rs
+++ b/src/clients/cache/momento/commands/mod.rs
@@ -4,6 +4,7 @@ use paste::paste;
 
 mod delete;
 mod get;
+mod get_batch;
 mod hash_delete;
 mod hash_get;
 mod hash_get_all;
@@ -29,6 +30,7 @@ mod sorted_set_score;
 
 pub use delete::*;
 pub use get::*;
+pub use get_batch::*;
 pub use hash_delete::*;
 pub use hash_get::*;
 pub use hash_get_all::*;

--- a/src/clients/cache/momento/mod.rs
+++ b/src/clients/cache/momento/mod.rs
@@ -95,6 +95,10 @@ async fn task(
                     set(&mut client, &config, cache_name, r).await
                 }
                 ClientRequest::Delete(r) => delete(&mut client, &config, cache_name, r).await,
+                ClientRequest::GetBatch(r) => {
+                    latency_histograms.push(&KVGETBATCH_RESPONSE_LATENCY);
+                    get_batch(&mut client, &config, cache_name, r).await
+                }
 
                 /*
                  * HASHES (DICTIONARIES)

--- a/src/clients/cache/momento/mod.rs
+++ b/src/clients/cache/momento/mod.rs
@@ -96,7 +96,7 @@ async fn task(
                 }
                 ClientRequest::Delete(r) => delete(&mut client, &config, cache_name, r).await,
                 ClientRequest::GetBatch(r) => {
-                    latency_histograms.push(&KVGETBATCH_RESPONSE_LATENCY);
+                    extra_histogram = Some(&KVGETBATCH_RESPONSE_LATENCY);
                     get_batch(&mut client, &config, cache_name, r).await
                 }
 

--- a/src/config/workload.rs
+++ b/src/config/workload.rs
@@ -338,7 +338,7 @@ impl Keyspace {
     }
 }
 
-#[derive(Clone, Copy, Deserialize)]
+#[derive(Clone, Copy, Deserialize, Debug)]
 pub struct Command {
     verb: Verb,
     #[serde(default = "one")]
@@ -409,6 +409,11 @@ pub enum Verb {
     /// * Momento: `get` (NOTE: cardinality > 1 is not supported)
     /// * RESP: `GET` or `MGET`
     Get,
+    /// Read the value for multiple keys.
+    /// * Memcache: `get`
+    /// * Momento: `get_batch`
+    /// * RESP: `GET` or `MGET`
+    GetBatch,
     /// Set the value for a key.
     /// * Memcache: `set`
     /// * Momento: `set`
@@ -584,6 +589,7 @@ impl Verb {
                 | Self::SortedSetAdd
                 | Self::SortedSetScore
                 | Self::SortedSetRemove
+                | Self::GetBatch
         )
     }
 

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -352,6 +352,22 @@ pub static RESPONSE_LATENCY: AtomicHistogram = AtomicHistogram::new(7, 64);
 pub static RESPONSE_LATENCY_HISTOGRAM: &str = "response_latency";
 
 #[metric(
+    name = KVGETBATCH_BATCH_SIZE_HISTOGRAM,
+    description = "Distribution of batch sizes for key-value GET BATCH requests",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static KVGETBATCH_BATCH_SIZE: AtomicHistogram = AtomicHistogram::new(7, 64);
+pub static KVGETBATCH_BATCH_SIZE_HISTOGRAM: &str = "kvgetbatch_batch_size";
+
+#[metric(
+    name = KVGETBATCH_RESPONSE_LATENCY_HISTOGRAM,
+    description = "Distribution of response latencies for key-value GET BATCH requests",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static KVGETBATCH_RESPONSE_LATENCY: AtomicHistogram = AtomicHistogram::new(7, 64);
+pub static KVGETBATCH_RESPONSE_LATENCY_HISTOGRAM: &str = "kvgetbatch_response_latency";
+
+#[metric(
     name = KVGET_RESPONSE_LATENCY_HISTOGRAM,
     description = "Distribution of response latencies for key-value GET requests",
     metadata = { unit = "nanoseconds" }

--- a/src/workload/client.rs
+++ b/src/workload/client.rs
@@ -19,7 +19,7 @@ pub struct Get {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct MultiGet {
+pub struct GetBatch {
     pub keys: Vec<Arc<[u8]>>,
 }
 
@@ -209,7 +209,7 @@ pub enum ClientRequest {
     Add(Add),
     Get(Get),
     Delete(Delete),
-    MultiGet(MultiGet),
+    GetBatch(GetBatch),
     Replace(Replace),
     Set(Set),
 

--- a/src/workload/mod.rs
+++ b/src/workload/mod.rs
@@ -356,6 +356,11 @@ impl Generator {
             Verb::Get => ClientRequest::Get(client::Get {
                 key: keyspace.sample(rng),
             }),
+            Verb::GetBatch => ClientRequest::GetBatch(client::GetBatch {
+                keys: (0..command.cardinality())
+                    .map(|_| keyspace.sample(rng))
+                    .collect(),
+            }),
             Verb::Set => ClientRequest::Set(client::Set {
                 key: keyspace.sample(rng),
                 value: keyspace.gen_value(sequence as _, rng),


### PR DESCRIPTION
## Summary
- Re-applies #418 (get_batch command support for Momento cache client)
- Fixes bug: `latency_histograms.push()` did not exist in scope — replaced with `extra_histogram = Some(&KVGETBATCH_RESPONSE_LATENCY)` to match the pattern used by Get/Set handlers

## Context
#418 was reverted in d8cc1b0 due to the latency histogram bug. This PR cherry-picks the original commit and applies the fix.

## Test plan
- [x] Verify `cargo build` succeeds
- [x] Verify get_batch latency metrics are correctly recorded via `extra_histogram`

🤖 Generated with [Claude Code](https://claude.com/claude-code)